### PR TITLE
Add JSONLines writer, plus simplify TSV to just use kgx sink

### DIFF
--- a/koza/app.py
+++ b/koza/app.py
@@ -10,7 +10,6 @@ from pydantic.error_wrappers import ValidationError
 
 from koza.exceptions import MapItemException
 from koza.io.writer.jsonl_writer import JSONLWriter
-from koza.io.writer.kgx_writer import KGXWriter
 from koza.io.writer.tsv_writer import TSVWriter
 from koza.io.writer.writer import KozaWriter
 from koza.model.config.source_config import MapFileConfig, OutputFormat, PrimaryFileConfig
@@ -87,8 +86,16 @@ class KozaApp:
     def get_writer(self, name):
         if self.output_format == OutputFormat.tsv:
             # TODO: node & edge property lists for output should move to source_file_config
-            node_properties = ["id", "category", "name", "description",	"provided_by"]
-            edge_properties = ["id", "subject",	"predicate", "object", "category", "relation", "provided_by"]
+            node_properties = ["id", "category", "name", "description", "provided_by"]
+            edge_properties = [
+                "id",
+                "subject",
+                "predicate",
+                "object",
+                "category",
+                "relation",
+                "provided_by",
+            ]
             return TSVWriter(self.output_dir, name, node_properties, edge_properties)
 
         elif self.output_format == OutputFormat.jsonl:

--- a/koza/app.py
+++ b/koza/app.py
@@ -9,7 +9,9 @@ import yaml
 from pydantic.error_wrappers import ValidationError
 
 from koza.exceptions import MapItemException
+from koza.io.writer.jsonl_writer import JSONLWriter
 from koza.io.writer.kgx_writer import KGXWriter
+from koza.io.writer.tsv_writer import TSVWriter
 from koza.io.writer.writer import KozaWriter
 from koza.model.config.source_config import MapFileConfig, OutputFormat, PrimaryFileConfig
 from koza.model.curie_cleaner import CurieCleaner
@@ -78,9 +80,19 @@ class KozaApp:
                             self.map_registry[map_file_config.name] = SourceFile(map_file_config)
 
             self.file_registry[source_file_config.name] = SourceFile(source_file_config)
-            self.writer_registry[source_file_config.name] = KGXWriter(
-                self.output_dir, self.output_format, f"{source.name}.{source_file_config.name}"
-            )
+
+            output_name = f"{source.name}.{source_file_config.name}"
+            self.writer_registry[source_file_config.name] = self.get_writer(output_name)
+
+    def get_writer(self, name):
+        if self.output_format == OutputFormat.tsv:
+            # TODO: node & edge property lists for output should move to source_file_config
+            node_properties = ["id", "category", "name", "description",	"provided_by"]
+            edge_properties = ["id", "subject",	"predicate", "object", "category", "relation", "provided_by"]
+            return TSVWriter(self.output_dir, name, node_properties, edge_properties)
+
+        elif self.output_format == OutputFormat.jsonl:
+            return JSONLWriter(self.output_dir, name)
 
     def get_map(self, map_name: str):
         pass

--- a/koza/io/writer/jsonl_writer.py
+++ b/koza/io/writer/jsonl_writer.py
@@ -1,2 +1,32 @@
-class JSONLWriter:
-    pass
+import json
+from dataclasses import asdict
+from typing import List
+
+from biolink_model_pydantic.model import Association, Entity, NamedThing
+from koza.io.writer.writer import KozaWriter
+
+
+class JSONLWriter(KozaWriter):
+    def __init__(self, output_dir: str, source_name: str):
+        self.output_dir = output_dir
+        self.source_name = source_name
+
+        self.nodes_file = open(f"{output_dir}/{source_name}_nodes.jsonl", "w")
+        self.edges_file = open(f"{output_dir}/{source_name}_edges.jsonl", "w")
+
+    def write(self, entities: List[Entity]):
+        for entity in entities:
+            if isinstance(entity, NamedThing):
+                node = json.dumps(asdict(entity), ensure_ascii=False)
+                self.nodes_file.write(node + '\n')
+            elif isinstance(entity, Association):
+                edge = json.dumps(asdict(entity), ensure_ascii=False)
+                self.edges_file.write(edge + '\n')
+            else:
+                raise ValueError(
+                    "Can only write NamedThing or Association entities"
+                )
+
+    def finalize(self):
+        self.nodes_file.close()
+        self.edges_file.close()

--- a/koza/io/writer/jsonl_writer.py
+++ b/koza/io/writer/jsonl_writer.py
@@ -3,6 +3,7 @@ from dataclasses import asdict
 from typing import List
 
 from biolink_model_pydantic.model import Association, Entity, NamedThing
+
 from koza.io.writer.writer import KozaWriter
 
 
@@ -23,9 +24,7 @@ class JSONLWriter(KozaWriter):
                 edge = json.dumps(asdict(entity), ensure_ascii=False)
                 self.edges_file.write(edge + '\n')
             else:
-                raise ValueError(
-                    "Can only write NamedThing or Association entities"
-                )
+                raise ValueError("Can only write NamedThing or Association entities")
 
     def finalize(self):
         self.nodes_file.close()

--- a/koza/io/writer/kgx_writer.py
+++ b/koza/io/writer/kgx_writer.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Optional
+from typing import Iterable
 
 from biolink_model_pydantic.model import Entity
 from kgx.graph.nx_graph import NxGraph
@@ -54,9 +54,3 @@ class KGXWriter(KozaWriter):
 
     def finalize(self):
         self.sink.finalize()
-
-    def writerow(self, row: Iterable[Any]) -> Optional[int]:
-        pass
-
-    def writerows(self, rows: Iterable[Iterable[Any]]) -> Optional[int]:
-        pass

--- a/koza/io/writer/tsv_writer.py
+++ b/koza/io/writer/tsv_writer.py
@@ -1,13 +1,15 @@
-
-from typing import List
-from biolink_model_pydantic.model import Association, Entity, NamedThing
 from dataclasses import asdict
+from typing import List
+
+from biolink_model_pydantic.model import Association, Entity, NamedThing
 
 from koza.io.writer.writer import KozaWriter
 
 
 class TSVWriter(KozaWriter):
-    def __init__(self, output_dir, source_name: str, node_properties: List[str], edge_properties: List[str]):
+    def __init__(
+        self, output_dir, source_name: str, node_properties: List[str], edge_properties: List[str]
+    ):
         self.output_dir = output_dir
         self.source_name = source_name
 
@@ -30,18 +32,16 @@ class TSVWriter(KozaWriter):
                 edge = self.convert_edge(entity)
                 self.edges_file.write(edge + '\n')
             else:
-                raise ValueError(
-                    "Can only write NamedThing or Association entities"
-                )
+                raise ValueError("Can only write NamedThing or Association entities")
 
     def finalize(self):
         self.nodes_file.close()
         self.edges_file.close()
 
-    def convert_node(self, entity:Entity):
+    def convert_node(self, entity: Entity):
         return self.convert_entity(entity, self.node_properties)
 
-    def convert_edge(self, entity:Entity):
+    def convert_edge(self, entity: Entity):
         return self.convert_entity(entity, self.edge_properties)
 
     def convert_entity(self, entity, properties: List[str]):
@@ -53,4 +53,3 @@ class TSVWriter(KozaWriter):
             values.append(value)
 
         return "\t".join(values)
-

--- a/koza/io/writer/tsv_writer.py
+++ b/koza/io/writer/tsv_writer.py
@@ -1,0 +1,56 @@
+
+from typing import List
+from biolink_model_pydantic.model import Association, Entity, NamedThing
+from dataclasses import asdict
+
+from koza.io.writer.writer import KozaWriter
+
+
+class TSVWriter(KozaWriter):
+    def __init__(self, output_dir, source_name: str, node_properties: List[str], edge_properties: List[str]):
+        self.output_dir = output_dir
+        self.source_name = source_name
+
+        self.node_properties = node_properties
+        self.edge_properties = edge_properties
+
+        self.nodes_file = open(f"{output_dir}/{source_name}_nodes.tsv", "w")
+        self.edges_file = open(f"{output_dir}/{source_name}_edges.tsv", "w")
+
+    def write(self, entities: List[Entity]):
+
+        self.nodes_file.write("\t".join(self.node_properties) + "\n")
+        self.edges_file.write("\t".join(self.edge_properties) + "\n")
+
+        for entity in entities:
+            if isinstance(entity, NamedThing):
+                node = self.convert_node(entity)
+                self.nodes_file.write(node + '\n')
+            elif isinstance(entity, Association):
+                edge = self.convert_edge(entity)
+                self.edges_file.write(edge + '\n')
+            else:
+                raise ValueError(
+                    "Can only write NamedThing or Association entities"
+                )
+
+    def finalize(self):
+        self.nodes_file.close()
+        self.edges_file.close()
+
+    def convert_node(self, entity:Entity):
+        return self.convert_entity(entity, self.node_properties)
+
+    def convert_edge(self, entity:Entity):
+        return self.convert_entity(entity, self.edge_properties)
+
+    def convert_entity(self, entity, properties: List[str]):
+        entity_dict = asdict(entity)
+
+        values = []
+        for prop in properties:
+            value = entity_dict[prop]
+            values.append(value)
+
+        return "\t".join(values)
+

--- a/koza/io/writer/tsv_writer.py
+++ b/koza/io/writer/tsv_writer.py
@@ -2,6 +2,7 @@ from dataclasses import asdict
 from typing import List
 
 from biolink_model_pydantic.model import Association, Entity, NamedThing
+from kgx.sink.tsv_sink import TsvSink
 
 from koza.io.writer.writer import KozaWriter
 
@@ -13,43 +14,22 @@ class TSVWriter(KozaWriter):
         self.output_dir = output_dir
         self.source_name = source_name
 
-        self.node_properties = node_properties
-        self.edge_properties = edge_properties
-
-        self.nodes_file = open(f"{output_dir}/{source_name}_nodes.tsv", "w")
-        self.edges_file = open(f"{output_dir}/{source_name}_edges.tsv", "w")
+        self.sink = TsvSink(
+            f"{output_dir}/{source_name}",
+            "tsv",
+            node_properties=node_properties,
+            edge_properties=edge_properties,
+        )
 
     def write(self, entities: List[Entity]):
 
-        self.nodes_file.write("\t".join(self.node_properties) + "\n")
-        self.edges_file.write("\t".join(self.edge_properties) + "\n")
-
         for entity in entities:
             if isinstance(entity, NamedThing):
-                node = self.convert_node(entity)
-                self.nodes_file.write(node + '\n')
+                self.sink.write_node(asdict(entity))
             elif isinstance(entity, Association):
-                edge = self.convert_edge(entity)
-                self.edges_file.write(edge + '\n')
+                self.sink.write_edge(asdict(entity))
             else:
                 raise ValueError("Can only write NamedThing or Association entities")
 
     def finalize(self):
-        self.nodes_file.close()
-        self.edges_file.close()
-
-    def convert_node(self, entity: Entity):
-        return self.convert_entity(entity, self.node_properties)
-
-    def convert_edge(self, entity: Entity):
-        return self.convert_entity(entity, self.edge_properties)
-
-    def convert_entity(self, entity, properties: List[str]):
-        entity_dict = asdict(entity)
-
-        values = []
-        for prop in properties:
-            value = entity_dict[prop]
-            values.append(value)
-
-        return "\t".join(values)
+        self.sink.finalize()

--- a/koza/io/writer/writer.py
+++ b/koza/io/writer/writer.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, Optional
+from typing import Iterable
 
 
 class KozaWriter(ABC):
@@ -17,12 +17,4 @@ class KozaWriter(ABC):
 
     @abstractmethod
     def finalize(self):
-        pass
-
-    @abstractmethod
-    def writerow(self, row: Iterable[Any]) -> Optional[int]:
-        pass
-
-    @abstractmethod
-    def writerows(self, rows: Iterable[Iterable[Any]]) -> Optional[int]:
         pass


### PR DESCRIPTION
I wrote a quick jsonl writer, then tried to follow on with a similarly quick tsv writer and it became really clear to me that the kgx tsv sink is really good, and there's just no reason that we should start from scratch to duplicate it's handling of lists and other sanitizing. 

I removed the previous kgx_writer, which approached writing with kgx through the Transform class, bypassing that altogether and simply using the sink has the added benefit of never having to create NxGraph nodes and edges. 

I added the start at specifying columns (the ones that are currently hardcoded are all that we were getting by default from kgx with the last tsv writer), but a next step will probably be to include node and edge property lists in the source_file_config yaml. 
 