### PR TITLE
Specifying node and edge properties as single flat lists for each source file

### DIFF
--- a/examples/string/protein-links-detailed.yaml
+++ b/examples/string/protein-links-detailed.yaml
@@ -27,3 +27,17 @@ filters:
 transform_code: './examples/string/protein-links-detailed.py'
 
 transform_mode: 'loop'
+
+node_properties:
+  - 'id'
+  - 'category'
+  - 'provided_by'
+
+edge_properties:
+  - 'id'
+  - 'subject'
+  - 'predicate'
+  - 'object'
+  - 'category'
+  - 'relation'
+  - 'provided_by'

--- a/examples/xenbase/gene-information.yaml
+++ b/examples/xenbase/gene-information.yaml
@@ -6,3 +6,23 @@ files:
 standard_format: 'gpi'
 
 compression: 'gzip'
+
+node_properties:
+  - 'id'
+  - 'category'
+  - 'provided_by'
+  - 'name'
+  - 'symbol'
+  - 'in_taxon'
+  - 'xref'
+  - 'synonyms'
+  - 'source'
+
+edge_properties:
+  - 'id'
+  - 'subject'
+  - 'predicate'
+  - 'object'
+  - 'category'
+  - 'relation'
+  - 'provided_by'

--- a/examples/xenbase/gene-literature.yaml
+++ b/examples/xenbase/gene-literature.yaml
@@ -14,3 +14,19 @@ columns:
 
 depends_on:
   - './examples/maps/genepage-2-gene.yaml'
+
+node_properties:
+  - 'id'
+  - 'category'
+  - 'provided_by'
+  - 'type'
+
+
+edge_properties:
+  - 'id'
+  - 'subject'
+  - 'predicate'
+  - 'object'
+  - 'category'
+  - 'relation'
+  - 'provided_by'

--- a/examples/xenbase/gene-to-phenotype.yaml
+++ b/examples/xenbase/gene-to-phenotype.yaml
@@ -4,3 +4,17 @@ files:
   - './examples/data/xb_xpo_spo_v20210511b.csv'
 
 standard_format: 'oban'
+
+node_properties:
+  - 'id'
+  - 'category'
+  - 'provided_by'
+
+edge_properties:
+  - 'id'
+  - 'subject'
+  - 'predicate'
+  - 'object'
+  - 'category'
+  - 'relation'
+  - 'provided_by'

--- a/koza/app.py
+++ b/koza/app.py
@@ -81,21 +81,10 @@ class KozaApp:
             self.file_registry[source_file_config.name] = SourceFile(source_file_config)
 
             output_name = f"{source.name}.{source_file_config.name}"
-            self.writer_registry[source_file_config.name] = self.get_writer(output_name)
+            self.writer_registry[source_file_config.name] = self.get_writer(output_name, source_file_config.node_properties, source_file_config.edge_properties)
 
-    def get_writer(self, name):
+    def get_writer(self, name, node_properties, edge_properties):
         if self.output_format == OutputFormat.tsv:
-            # TODO: node & edge property lists for output should move to source_file_config
-            node_properties = ["id", "category", "name", "description", "provided_by"]
-            edge_properties = [
-                "id",
-                "subject",
-                "predicate",
-                "object",
-                "category",
-                "relation",
-                "provided_by",
-            ]
             return TSVWriter(self.output_dir, name, node_properties, edge_properties)
 
         elif self.output_format == OutputFormat.jsonl:

--- a/koza/io/writer/tsv_writer.py
+++ b/koza/io/writer/tsv_writer.py
@@ -14,12 +14,18 @@ class TSVWriter(KozaWriter):
         self.output_dir = output_dir
         self.source_name = source_name
 
-        self.sink = TsvSink(
-            f"{output_dir}/{source_name}",
-            "tsv",
-            node_properties=node_properties,
-            edge_properties=edge_properties,
-        )
+        if node_properties and edge_properties:
+            self.sink = TsvSink(
+                f"{output_dir}/{source_name}",
+                "tsv",
+                node_properties=node_properties,
+                edge_properties=edge_properties,
+            )
+        else: # allow the TsvSink to set defaults if no properties are specified
+            self.sink = TsvSink(
+                f"{output_dir}/{source_name}",
+                "tsv"
+            )
 
     def write(self, entities: List[Entity]):
 

--- a/koza/model/config/source_config.py
+++ b/koza/model/config/source_config.py
@@ -154,6 +154,8 @@ class SourceFileConfig:
     standard_format: StandardFormat = None
     file_metadata: DatasetDescription = None
     columns: List[Union[str, Dict[str, FieldType]]] = None
+    node_properties: List[str] = None
+    edge_properties: List[str] = None
     required_properties: List[str] = None
     delimiter: str = None
     header_delimiter: str = None


### PR DESCRIPTION
An interesting caveat to this is that column lists don't determine order, the KGX sink itself does that (which is probably a good thing, since it's more consistent than having to get it right in config files)