### PR TITLE
Fixed examples plus flit script config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Send a local or remove csv file through Koza to get some basic information (head
 
 ```bash
 koza validate \
-  --file https://raw.githubusercontent.com/monarch-initiative/koza/dev/tests/resources/source-files/string.tsv \
+  --file https://raw.githubusercontent.com/monarch-initiative/koza/main/examples/data/string.tsv \
   --delimiter ' '
 ```
 
@@ -51,7 +51,7 @@ koza validate \
 ###### Example: transforming StringDB
 
 ```bash
-koza transform --source examples/string/metadata.yaml 
+koza transform --source examples/string/protein-links-detailed.yaml --global-table examples/translation_table.yaml 
 
-koza transform --source examples/string-declarative/metadata.yaml 
+koza transform --source examples/string-declarative/protein-links-detailed.yaml --global-table examples/translation_table.yaml
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,3 +60,13 @@ koza transform --source examples/string/metadata.yaml
 
 koza transform --source examples/string-declarative/metadata.yaml 
 ```
+#### Running an ingest from within a python script
+
+Executing a koza transform from within a python script can be done by calling transform_source from koza.cli_runner
+
+```python
+from koza.cli_runner import transform_source
+
+transform_source("./examples/string/protein-links-detailed.yaml",
+                 "output", "tsv", "./examples/translation_table.yaml", None)
+```

--- a/koza/__init__.py
+++ b/koza/__init__.py
@@ -1,2 +1,2 @@
 """Koza, an ETL framework for the Biolink model"""
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/koza/cli_runner.py
+++ b/koza/cli_runner.py
@@ -36,7 +36,7 @@ def set_koza_app(
     source: Source,
     translation_table: TranslationTable = None,
     output_dir: str = './output',
-    output_format: OutputFormat = OutputFormat('jsonl'),
+    output_format: OutputFormat = OutputFormat('tsv'),
 ) -> KozaApp:
     """
     Setter for singleton koza app object
@@ -124,7 +124,7 @@ def get_translation_table(global_table: str = None, local_table: str = None) -> 
 def transform_source(
     source: str,
     output_dir: str,
-    output_format: OutputFormat,
+    output_format: OutputFormat = OutputFormat('tsv'),
     global_table: str = None,
     local_table: str = None,
 ):

--- a/koza/io/utils.py
+++ b/koza/io/utils.py
@@ -32,7 +32,7 @@ def open_resource(resource: Union[str, PathLike], compression: CompressionType =
     :return: str, next line in resource
 
     """
-    if isinstance(resource, PosixPath) and Path(resource).exists():
+    if Path(resource).exists():
         if compression is None:
             # Try gzip first
             try:

--- a/koza/main.py
+++ b/koza/main.py
@@ -22,7 +22,7 @@ LOG = logging.getLogger(__name__)
 def transform(
     source: str = typer.Option(..., help="Source metadata file"),
     output_dir: str = typer.Option('./output', help="Path to output directory"),
-    output_format: OutputFormat = typer.Option("jsonl", help="Output format"),
+    output_format: OutputFormat = typer.Option("tsv", help="Output format"),
     global_table: str = typer.Option(None, help="Path to global translation table"),
     local_table: str = typer.Option(None, help="Path to local translation table"),
     quiet: bool = False,

--- a/koza/model/config/source_config.py
+++ b/koza/model/config/source_config.py
@@ -94,7 +94,7 @@ class OutputFormat(str, Enum):
     Output formats
     """
 
-    tsv = 'tsv'  # TODO
+    tsv = 'tsv'
     jsonl = 'jsonl'
     kgx = 'kgx'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
 ]
 
 [tool.flit.scripts]
-koza = "koza:main.app"
+koza = "koza:main.typer_app"
 
 [tool.black]
 line_length = 100


### PR DESCRIPTION
The flit config bit was causing an error when koza is called from the command line, and the examples were just still pointing to the metadata file