### PR TITLE
fixes bug in custom maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # IDE
 .idea
+
+# output directories
+output/
+test-output/

--- a/examples/maps/custom-entrez-2-string.py
+++ b/examples/maps/custom-entrez-2-string.py
@@ -1,6 +1,6 @@
 from koza.cli_runner import koza_app
 
-source_name = "custom_entrez_2_string"
+source_name = "custom-entrez-2-string"
 
 row = koza_app.get_row(source_name)
 

--- a/examples/maps/custom-entrez-2-string.yaml
+++ b/examples/maps/custom-entrez-2-string.yaml
@@ -1,4 +1,4 @@
-name: 'custom_entrez_2_string'
+name: 'custom-entrez-2-string'
 
 metadata:
   description: 'Mapping file provided by StringDB that contains entrez to protein ID mappings'
@@ -9,12 +9,10 @@ header_delimiter: '/'
 # Assumes that no identifiers are overlapping
 # otherwise these should go into separate configs
 files:
-  - './examples/data/human.entrez_2_string.2018.tsv.gz'
-  - './examples/data/mouse.entrez_2_string.2018.tsv.gz'
-  - './examples/data/zebrafish.entrez_2_string.2018.tsv.gz'
-  - './examples/data/fly.entrez_2_string.2018.tsv.gz'
-  - './examples/data/celegans.entrez_2_string.2018.tsv.gz'
-  - './examples/data/yeast.entrez_2_string.2018.tsv.gz'
+  - './examples/data/entrez-2-string.tsv'
+  - './examples/data/additional-entrez-2-string.tsv'
+
+header: 0
 
 columns:
   - 'NCBI taxid'

--- a/examples/string-w-custom-map/protein-links-detailed.py
+++ b/examples/string-w-custom-map/protein-links-detailed.py
@@ -5,7 +5,7 @@ from biolink_model_pydantic.model import Gene, PairwiseGeneToGeneInteraction, Pr
 from koza.cli_runner import koza_app
 
 row = koza_app.get_row()
-entrez_2_string = koza_app.get_map('custom_entrez_2_string')
+entrez_2_string = koza_app.get_map('custom-entrez-2-string')
 
 gene_a = Gene(id='NCBIGene:' + entrez_2_string[row['protein1']]['entrez'])
 gene_b = Gene(id='NCBIGene:' + entrez_2_string[row['protein2']]['entrez'])

--- a/koza/__init__.py
+++ b/koza/__init__.py
@@ -1,2 +1,2 @@
 """Koza, an ETL framework for LinkML data models"""
-__version__ = '0.1.3'
+__version__ = '0.1.4'

--- a/koza/app.py
+++ b/koza/app.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 import sys
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Union
 
 import yaml
 from pydantic.error_wrappers import ValidationError
@@ -61,11 +61,6 @@ class KozaApp:
         self.writer = self._get_writer(
             source.config.name, source.config.node_properties, source.config.edge_properties
         )
-
-        # load the map cache
-        for map_file in self._map_registry.values():
-            if map_file.config.name not in self._map_cache:
-                self._load_map(map_file.config)
 
     def get_map(self, map_name: str):
         return self._map_cache[map_name]
@@ -129,6 +124,15 @@ class KozaApp:
         # remove directory from sys.path to prevent name clashes
         sys.path.remove(str(parent_path))
 
+    def process_maps(self):
+        """
+        Initializes self._map_cache
+        :return:
+        """
+        for map_file in self._map_registry.values():
+            if map_file.config.name not in self._map_cache:
+                self._load_map(map_file.config)
+
     @staticmethod
     def next_row():
         """
@@ -144,7 +148,7 @@ class KozaApp:
     def write(self, *entities):
         self.writer.write(entities)
 
-    def _get_writer(self, name, node_properties, edge_properties):
+    def _get_writer(self, name, node_properties, edge_properties) -> Union[TSVWriter, JSONLWriter]:
         if self.output_format == OutputFormat.tsv:
             return TSVWriter(self.output_dir, name, node_properties, edge_properties)
 

--- a/koza/cli_runner.py
+++ b/koza/cli_runner.py
@@ -144,4 +144,5 @@ def transform_source(
         koza_source = Source(source_config)
 
         koza_app = set_koza_app(koza_source, translation_table, output_dir, output_format)
+        koza_app.process_maps()
         koza_app.process_sources()

--- a/koza/model/translation_table.py
+++ b/koza/model/translation_table.py
@@ -41,9 +41,6 @@ class TranslationTable:
         if not is_dictionary_bimap(self.global_table):
             raise ValueError("Global table is not a bimap")
 
-        if not is_dictionary_bimap(self.local_table):
-            raise ValueError("Local table is not a bimap")
-
     def resolve_term(
         self, word: str, mandatory: Optional[bool] = True, default: Optional[str] = None
     ):

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -44,6 +44,8 @@ from koza.model.config.source_config import OutputFormat
         ),
         ("string-w-map", ["protein-links-detailed"], OutputFormat.tsv),
         ("string-w-map", ["protein-links-detailed"], OutputFormat.jsonl),
+        ("string-w-custom-map", ["protein-links-detailed"], OutputFormat.tsv),
+        ("string-w-custom-map", ["protein-links-detailed"], OutputFormat.jsonl),
     ],
 )
 def test_examples(ingest, output_names, output_format):


### PR DESCRIPTION
Currently custom maps raise an exception when interating over rows in a map file:

```koza_app.get_row(source_name)```

because koza_app has not yet been initialized.  This moves the map processing code out of the koza_app __init__ so that this works.