### PR TITLE
Feature/tsv writer

### DIFF
--- a/koza/converter/kgx_converter.py
+++ b/koza/converter/kgx_converter.py
@@ -1,7 +1,7 @@
 from dataclasses import asdict
 from typing import Iterable, Tuple
 
-from biolink_model_pydantic.model import Association, NamedThing
+#from biolink_model_pydantic.model import Association, NamedThing
 
 class KGXConverter:
     """
@@ -21,10 +21,16 @@ class KGXConverter:
         edges = []
 
         for entity in entities:
-            if isinstance(entity, NamedThing):
-                nodes.append(self.convert_node(entity))
-            elif isinstance(entity, Association):
+
+            # if entity has subject + object + predicate, treat as edge
+            if all(hasattr(entity, attr) for attr in ["subject", "object", "predicate"]):
                 edges.append(self.convert_association(entity))
+
+            # if entity has id and name, but not subject/object/predicate, treat as node
+            elif all(hasattr(entity, attr) for attr in ["id", "name"]) and not all(hasattr(entity, attr) for attr in ["subject", "object", "predicate"]):
+                nodes.append(self.convert_node(entity))
+
+            # otherwise, not a 
             else:
                 raise ValueError(
                     "Can only convert NamedThing or Association entities to KGX compatible dictionaries"
@@ -32,8 +38,8 @@ class KGXConverter:
 
         return nodes, edges
 
-    def convert_node(self, node: NamedThing) -> dict:
+    def convert_node(self, node) -> dict:
         return asdict(node)
 
-    def convert_association(self, association: Association) -> dict:
+    def convert_association(self, association) -> dict:
         return asdict(association)

--- a/koza/converter/kgx_converter.py
+++ b/koza/converter/kgx_converter.py
@@ -1,8 +1,6 @@
 from dataclasses import asdict
 from typing import Iterable, Tuple
 
-#from biolink_model_pydantic.model import Association, NamedThing
-
 class KGXConverter:
     """
     Converts the biolink model to the KGX format, which splits

--- a/koza/io/writer/jsonl_writer.py
+++ b/koza/io/writer/jsonl_writer.py
@@ -1,33 +1,36 @@
 import json
 import os
 from dataclasses import asdict
-from typing import List
-
-from biolink_model_pydantic.model import Association, Entity, NamedThing
+from typing import Iterable
 
 from koza.io.writer.writer import KozaWriter
-
+from koza.converter.kgx_converter import KGXConverter
 
 class JSONLWriter(KozaWriter):
     def __init__(self, output_dir: str, source_name: str):
+
         self.output_dir = output_dir
         self.source_name = source_name
+
+        self.converter = KGXConverter()
 
         os.makedirs(output_dir, exist_ok=True)
 
         self.nodes_file = open(f"{output_dir}/{source_name}_nodes.jsonl", "w")
         self.edges_file = open(f"{output_dir}/{source_name}_edges.jsonl", "w")
 
-    def write(self, entities: List[Entity]):
-        for entity in entities:
-            if isinstance(entity, NamedThing):
-                node = json.dumps(asdict(entity), ensure_ascii=False)
-                self.nodes_file.write(node + '\n')
-            elif isinstance(entity, Association):
-                edge = json.dumps(asdict(entity), ensure_ascii=False)
+    def write(self, entities: Iterable):
+
+        (nodes, edges) = self.converter.convert(entities)
+
+        for n in nodes:
+            node = json.dumps(n, ensure_ascii=False)
+            self.nodes_file.write(node + '\n')
+
+        if edges:
+            for e in edges:
+                edge = json.dumps(e, ensure_ascii=False)
                 self.edges_file.write(edge + '\n')
-            else:
-                raise ValueError("Can only write NamedThing or Association entities")
 
     def finalize(self):
         self.nodes_file.close()

--- a/koza/io/writer/tsv_writer.py
+++ b/koza/io/writer/tsv_writer.py
@@ -11,8 +11,6 @@ from ordered_set import OrderedSet
 from koza.converter.kgx_converter import KGXConverter
 from koza.io.utils import build_export_row
 from koza.io.writer.writer import KozaWriter
-
-#from kgx.sink.tsv_sink import TsvSink
 class TSVWriter(KozaWriter): 
     def __init__(
         self, output_dir, source_name: str, node_properties: List[str], edge_properties: Optional[List[str]]=[]

--- a/koza/io/writer/tsv_writer.py
+++ b/koza/io/writer/tsv_writer.py
@@ -15,36 +15,23 @@ from koza.io.writer.writer import KozaWriter
 #from kgx.sink.tsv_sink import TsvSink
 class TSVWriter(KozaWriter): 
     def __init__(
-        self, output_dir, source_name: str, node_properties: List[str], edge_properties: List[str]
+        self, output_dir, source_name: str, node_properties: List[str], edge_properties: Optional[List[str]]=[]
     ):
         self.dirname = output_dir
         self.basename = source_name
-
-        self.node_properties = node_properties
-        self.edge_properties = edge_properties
-
+        
         self.delimiter = "\t"
-        self.converter = KGXConverter()
-        
-        self.nodes_file_basename = f"{self.basename}_nodes.tsv"
-        self.edges_file_basename = f"{self.basename}_edges.tsv"
-        
-        if not node_properties or not edge_properties:
-            raise ValueError("node_properties and edge_properties must be provided to TSVWriter class.\nMake sure you define node and edge properties in your source config yaml.")
-
-        """
-        if core_edge_properies not in edge_properties:
-            you gotta set these
-        """
-        
-        self.ordered_node_columns = TSVWriter._order_node_columns(self.node_properties)
-        self.ordered_edge_columns = TSVWriter._order_edge_columns(self.edge_properties)
-
         self.list_delimiter = "|"
+        
+        self.converter = KGXConverter()
 
         # Create output directory
         os.makedirs(self.dirname, exist_ok=True)
 
+        self.node_properties = node_properties
+        self.nodes_file_basename = f"{self.basename}_nodes.tsv"
+        self.ordered_node_columns = TSVWriter._order_node_columns(self.node_properties)
+        
         # Create and write to nodes output file
         self.nodes_file_name = os.path.join(
             self.dirname if self.dirname else "", self.nodes_file_basename
@@ -52,12 +39,18 @@ class TSVWriter(KozaWriter):
         self.NFH = open(self.nodes_file_name, "w")
         self.NFH.write(self.delimiter.join(self.ordered_node_columns) + "\n")
 
-        # Create and write to edges output file
-        self.edges_file_name = os.path.join(
-            self.dirname if self.dirname else "", self.edges_file_basename
-        )
-        self.EFH = open(self.edges_file_name, "w")
-        self.EFH.write(self.delimiter.join(self.ordered_edge_columns) + "\n")
+        if edge_properties:
+            self.has_edge = True
+            self.edge_properties = edge_properties
+            self.edges_file_basename = f"{self.basename}_edges.tsv"
+            self.ordered_edge_columns = TSVWriter._order_edge_columns(self.edge_properties)
+
+            # Create and write to edges output file
+            self.edges_file_name = os.path.join(
+                self.dirname if self.dirname else "", self.edges_file_basename
+            )
+            self.EFH = open(self.edges_file_name, "w")
+            self.EFH.write(self.delimiter.join(self.ordered_edge_columns) + "\n")
                 
 
     def write(self, entities: Iterable):
@@ -70,8 +63,9 @@ class TSVWriter(KozaWriter):
         for node in nodes:
             self.write_node(node)
 
-        for edge in edges:
-            self.write_edge(edge)
+        if edges:
+            for edge in edges:
+                self.write_edge(edge)
 
     def write_node(self, record: Dict) -> None:
         """
@@ -114,7 +108,8 @@ class TSVWriter(KozaWriter):
         Close file handles and create an archive if compression mode is defined.
         """
         self.NFH.close()
-        self.EFH.close()
+        if hasattr(self, 'EFH'):
+            self.EFH.close() 
 
     @staticmethod
     def _order_node_columns(cols: Set) -> OrderedSet:
@@ -163,15 +158,7 @@ class TSVWriter(KozaWriter):
         """
         edge_columns = cols.copy()
         core_columns = OrderedSet(
-            [
-                "id",
-                "subject",
-                "predicate",
-                "object",
-                "category",
-                "relation",
-                "provided_by",
-            ]
+            ["id","subject","predicate","object","category","relation","provided_by"]
         )
         ordered_columns = OrderedSet()
         for c in core_columns:

--- a/tests/unit/test_tsvwriter_node_and_edge.py
+++ b/tests/unit/test_tsvwriter_node_and_edge.py
@@ -14,16 +14,15 @@ def test_tsv_writer():
                                 relation="RO:0003304",
                                 predicate=Predicate.contributes_to,
                                 )
-    ent = [g, d]
+    ent = [g, d, a]
 
     node_properties = ['id','category','symbol','in_taxon','provided_by','source']
     edge_properties = ['id','subject','predicate','object','category','relation','qualifiers','publications','provided_by','source']
 
     outdir = "test-output"
-    outfile = "todd"
+    outfile = "tsvwriter-node-and-edge"
 
     t = TSVWriter(outdir, outfile, node_properties, edge_properties)
-    
     t.write(ent)
     t.finalize()
 

--- a/tests/unit/test_tsvwriter_node_only.py
+++ b/tests/unit/test_tsvwriter_node_only.py
@@ -1,0 +1,23 @@
+import os
+from biolink_model_pydantic.model import Gene, Disease, GeneToDiseaseAssociation, Predicate
+from koza.io.writer.tsv_writer import TSVWriter
+
+def test_tsv_writer():
+    """
+    Writes a test tsv file
+    """
+    g = Gene(id="HGNC:11603", name="TBX4")
+    d = Disease(id="MONDO:0005002", name="chronic obstructive pulmonary disease")
+
+    ent = [g, d]
+
+    node_properties = ['id','category','symbol','in_taxon','provided_by','source']
+    
+    outdir = "test-output"
+    outfile = "tsvwriter-node-only"
+
+    t = TSVWriter(outdir, outfile, node_properties)
+    t.write(ent)
+    t.finalize()
+
+    assert os.path.exists("{}/{}_nodes.tsv".format(outdir, outfile))


### PR DESCRIPTION
- Dropped biolink-model-pydantic dependency from kgx_converter (and io/writer/jsonl_writer) 
	- now use `hasattr` to check for ["subject", "object", "predicate"]
	- if yes, treat as edge
	- if no, but has ["id", "name"], treat as node
	- else raise "only NamedThing or Association entities"

- Added check in tsv_writer for whether edge properties are passed. if not, don't write an empty edge tsv

I believe these changes should address #62 and #70 !