### PR TITLE
Bump pyyaml to 6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires = [
     "pydantic >=1.0.0,<2.0.0",
-    "pyyaml >=5.3.1,<6.0.0",
+    "pyyaml >=6.0.0",
     "requests >=2.24.0,<3.0.0",
     "typer >=0.3",
     "ordered-set >= 4.1.0",


### PR DESCRIPTION
Versions of pyyaml below 6.0 create a dependency conflict with `prefixmaps`.
Bumping the version up to 6.0 appears to work for the most part, with the exception of a single test:
```
=================================== FAILURES ===================================
___________________________ test_valid_input[gene0] ____________________________

gene = {'category': ['biolink:NamedThing', 'biolink:Gene'], 'id': 'BOGUS:12345', 'name': 'Bogus Gene 12345'}

    @pytest.mark.parametrize("gene", [valid_gene])
    def test_valid_input(gene):
        validator = Validator(schema="tests/resources/biolink-model.yaml")
        v = validator.validate(obj=gene, target_class="NamedThing")
        result = v.validation_results[0]
>       assert result.valid == True
E       assert False == True
E        +  where False = ValidationResult(plugin_name='JsonSchemaValidationPlugin', valid=False, validation_messages=[ValidationMessage(severit..., field=None, value=None, message="Additional properties are not allowed ('category', 'id', 'name' were unexpected)")]).valid

tests/unit/test_validation.py:22: AssertionError
=========================== short test summary info ============================
FAILED tests/unit/test_validation.py::test_valid_input[gene0] - assert False ...
================== 1 failed, 103 passed in 318.04s (0:05:18) ===================
```

Any other reason that `pyyaml` is pinned to <6.0?