### PR TITLE
Metadata.yaml opened as TextIOWrapper rather than a str

### DIFF
--- a/koza/model/config/source_config.py
+++ b/koza/model/config/source_config.py
@@ -223,12 +223,14 @@ class SourceConfig:
             # TODO enforce that this is imported via an include?
             # See https://github.com/monarch-initiative/koza/issues/46
             try:
-                object.__setattr__(
-                    self, 'metadata', DatasetDescription(**yaml.safe_load(self.metadata))
-                )
-            except Exception:
+                with open(self.metadata, 'r') as meta:
+                    object.__setattr__(
+                        self, 'metadata', DatasetDescription(**yaml.safe_load(meta))
+                    )
+            except Exception as e:
                 # TODO check for more explicit exceptions
-                LOG.debug("Could not load dataset description from metadata file")
+                raise ValueError(f"Unable to load metadata from {self.metadata}: {e}")
+                # LOG.debug("Could not load dataset description from metadata file")
 
         if self.delimiter in ['tab', '\\t']:
             object.__setattr__(self, 'delimiter', '\t')


### PR DESCRIPTION
Fixes #103

- [x] Opens the metadata.yaml file using `with open()` and then `yaml.safe_load()` as opposed to directly opening string path using `yaml_safe_load()`
- [x] Raise an error rather than logging a warning.