### PR TITLE
Change YAML path resolution

### DIFF
--- a/examples/maps/custom-entrez-2-string.yaml
+++ b/examples/maps/custom-entrez-2-string.yaml
@@ -11,8 +11,8 @@ reader:
   # Assumes that no identifiers are overlapping
   # otherwise these should go into separate configs
   files:
-    - './examples/data/entrez-2-string.tsv'
-    - './examples/data/additional-entrez-2-string.tsv'
+    - '../data/entrez-2-string.tsv'
+    - '../data/additional-entrez-2-string.tsv'
 
   header_mode: 0
 

--- a/examples/maps/entrez-2-string.yaml
+++ b/examples/maps/entrez-2-string.yaml
@@ -13,8 +13,8 @@ reader:
   # Assumes that no identifiers are overlapping
   # otherwise these should go into separate configs
   files:
-    - './examples/data/entrez-2-string.tsv'
-    - './examples/data/additional-entrez-2-string.tsv'
+    - '../data/entrez-2-string.tsv'
+    - '../data/additional-entrez-2-string.tsv'
 
   columns:
     - 'NCBI taxid'

--- a/examples/maps/genepage-2-gene.yaml
+++ b/examples/maps/genepage-2-gene.yaml
@@ -5,7 +5,7 @@ metadata:
 delimiter: '\t'
 
 files:
-  - './examples/data/XenbaseGenepageToGeneIdMapping.txt'
+  - '../data/XenbaseGenepageToGeneIdMapping.txt'
 
 columns:
   - 'gene_page_id'

--- a/examples/string-declarative/declarative-protein-links-detailed.yaml
+++ b/examples/string-declarative/declarative-protein-links-detailed.yaml
@@ -12,8 +12,8 @@ reader:
   delimiter: ' '
 
   files:
-    - './examples/data/string.tsv'
-    - './examples/data/string2.tsv'
+    - '../data/string.tsv'
+    - '../data/string2.tsv'
 
   columns:
     - 'protein1'

--- a/examples/string-w-custom-map/custom-map-protein-links-detailed.yaml
+++ b/examples/string-w-custom-map/custom-map-protein-links-detailed.yaml
@@ -1,13 +1,13 @@
 name: 'custom-map-protein-links-detailed'
 
-metadata: !include './examples/string-w-custom-map/metadata.yaml'
+metadata: !include 'metadata.yaml'
 
 reader:
   delimiter: ' '
 
   files:
-    - './examples/data/string.tsv'
-    - './examples/data/string2.tsv'
+    - '../data/string.tsv'
+    - '../data/string2.tsv'
 
   columns:
     - 'protein1'
@@ -29,7 +29,7 @@ transform:
       value: 700
 
   mappings:
-    - 'examples/maps/custom-entrez-2-string.yaml'
+    - '../maps/custom-entrez-2-string.yaml'
 
 writer:
   node_properties:

--- a/examples/string-w-map/map-protein-links-detailed.yaml
+++ b/examples/string-w-map/map-protein-links-detailed.yaml
@@ -1,13 +1,13 @@
 name: 'map-protein-links-detailed'
 
-metadata: !include './examples/string-w-map/metadata.yaml'
+metadata: !include 'metadata.yaml'
 
 reader:
   format: csv
   delimiter: ' '
   files:
-    - './examples/data/string.tsv'
-    - './examples/data/string2.tsv'
+    - '../data/string.tsv'
+    - '../data/string2.tsv'
 
   columns:
     - 'protein1'
@@ -28,7 +28,7 @@ transform:
       filter_code: 'lt'
       value: 700
   mappings:
-    - './examples/maps/entrez-2-string.yaml'
+    - '../maps/entrez-2-string.yaml'
 
 writer:
   node_properties:

--- a/examples/string/protein-links-detailed.yaml
+++ b/examples/string/protein-links-detailed.yaml
@@ -1,16 +1,16 @@
 name: 'protein-links-detailed'
-metadata: !include './examples/string/metadata.yaml'
+metadata: !include './metadata.yaml'
 
 reader:
   format: csv
   files:
-    - './examples/data/string.tsv'
-    - './examples/data/string2.tsv'
+    - '../data/string.tsv'
+    - '../data/string2.tsv'
   delimiter: ' '
-  columns: !include './examples/standards/string.yaml'
+  columns: !include '../standards/string.yaml'
 
 transform:
-  code: './examples/string/protein-links-detailed.py'
+  code: 'protein-links-detailed.py'
   filters:
     - inclusion: 'include'
       column: 'combined_score'

--- a/src/koza/io/yaml_loader.py
+++ b/src/koza/io/yaml_loader.py
@@ -11,6 +11,9 @@ Include loader based on: https://matthewpburruss.com/post/yaml/ and
                          https://stackoverflow.com/a/9577670
 """
 
+from pathlib import Path
+from typing import TextIO
+
 import yaml
 from yaml import SafeLoader
 from yaml.constructor import ConstructorError
@@ -25,6 +28,10 @@ class UniqueIncludeLoader(SafeLoader):
     - an '!include' tag for importing other yaml files
     """
 
+    def __init__(self, stream: str | TextIO, base_filename: str):
+        super().__init__(stream)
+        self._base_path = Path(base_filename).parent
+
     def unique_construct_mapping(self, node: yaml.MappingNode, deep=False):
         mapping = []
         for key_node, value_node in node.value:
@@ -34,16 +41,25 @@ class UniqueIncludeLoader(SafeLoader):
             mapping.append(key)
         return super().construct_mapping(node, deep)
 
+    @classmethod
+    def with_file_base(cls, base_filename: str):
+        class LoaderWithBase(cls):
+            def __init__(self, stream: str | TextIO):
+                super().__init__(stream, base_filename)
+        return LoaderWithBase
 
-def include_constructor(loader: yaml.SafeLoader, node: yaml.ScalarNode):
+
+def include_constructor(loader: UniqueIncludeLoader, node: yaml.ScalarNode):
     """
     Opens some resource (local or remote file) that appears after an !include tag
     """
     filename = loader.construct_scalar(node)
-    resource = open_resource(filename)
+    resolved_path = loader._base_path / filename
+    resource = open_resource(resolved_path)
     if isinstance(resource, tuple):
         raise ValueError("Cannot load yaml from archive files")
-    return yaml.load(resource.reader, Loader=UniqueIncludeLoader)  # noqa: S506
+
+    return yaml.load(resource.reader, Loader=UniqueIncludeLoader.with_file_base(str(resolved_path)))  # noqa: S506
 
 
 UniqueIncludeLoader.add_constructor("!include", include_constructor)

--- a/src/koza/main.py
+++ b/src/koza/main.py
@@ -2,7 +2,7 @@
 """CLI for Koza - wraps the koza library to provide a command line interface"""
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Optional
 
 import typer
 from loguru import logger
@@ -17,7 +17,7 @@ typer_app = typer.Typer(
 
 
 @typer_app.callback(invoke_without_command=True)
-def callback(version: bool | None = typer.Option(None, "--version", is_eager=True)):
+def callback(version: Optional[bool] = typer.Option(None, "--version", is_eager=True)):
     if version:
         from koza import __version__
 

--- a/src/koza/model/source.py
+++ b/src/koza/model/source.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from pathlib import Path
 from tarfile import TarFile
 from typing import Any, TextIO
 from zipfile import ZipFile
@@ -27,7 +28,7 @@ class Source:
     reader: An iterator that takes in an IO[str] and yields a dictionary
     """
 
-    def __init__(self, config: KozaConfig, row_limit: int = 0, show_progress: bool = False):
+    def __init__(self, config: KozaConfig, base_directory: Path, row_limit: int = 0, show_progress: bool = False):
         reader_config = config.reader
 
         self.row_limit = row_limit
@@ -39,7 +40,10 @@ class Source:
         self._opened: list[ZipFile | TarFile | TextIO] = []
 
         for file in reader_config.files:
-            opened_resource = open_resource(file)
+            file_path = Path(file)
+            if not file_path.is_absolute():
+                file_path = base_directory / file_path
+            opened_resource = open_resource(file_path)
             if isinstance(opened_resource, tuple):
                 archive, resources = opened_resource
                 self._opened.append(archive)

--- a/src/koza/runner.py
+++ b/src/koza/runner.py
@@ -217,11 +217,15 @@ class KozaRunner:
             logger.info("Loading mappings")
 
         for mapping_config_filename in self.mapping_filenames:
-            if self.base_directory is None:
-                raise ValueError("Cannot load config maps without a `base_directory` set.")
+            mapping_config = Path(mapping_config_filename)
+            if not mapping_config.is_absolute():
+                if self.base_directory is None:
+                    raise ValueError("Cannot load config maps without a `base_directory` set.")
+                mapping_config = self.base_directory / mapping_config
+
             # Check if a transform has been defined for the mapping
             config, map_runner = KozaRunner.from_config_file(
-                str(self.base_directory / mapping_config_filename),
+                str(mapping_config),
                 output_format=OutputFormat.passthrough,
             )
             try:
@@ -273,7 +277,9 @@ class KozaRunner:
         transform_module: ModuleType | None = None
 
         if config.transform.code:
-            transform_code_path = base_directory / config.transform.code
+            transform_code_path = Path(config.transform.code)
+            if not transform_code_path.is_absolute():
+                transform_code_path = base_directory / transform_code_path
             parent_path = transform_code_path.absolute().parent
             module_name = transform_code_path.stem
             logger.debug(f"Adding `{parent_path}` to system path to load transform module")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,6 +11,7 @@ runner = CliRunner()
 def test_cli():
     config_file = (Path(__file__).parent / "../../examples/string/protein-links-detailed.yaml").resolve()
     test_output_dir = (Path(__file__).parent / "../output").resolve()
+    test_output_dir.mkdir(exist_ok=True)
 
     with tempfile.TemporaryDirectory(dir=test_output_dir) as output_dir:
         result = runner.invoke(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,32 @@
-"""
-Unit tests for the cli interface
+import tempfile
+from pathlib import Path
 
-This is a stub - see https://typer.tiangolo.com/tutorial/testing/
-"""
+from typer.testing import CliRunner
+
+from koza.main import typer_app
+
+runner = CliRunner()
+
+
+def test_cli():
+    config_file = (Path(__file__).parent / "../../examples/string/protein-links-detailed.yaml").resolve()
+    test_output_dir = (Path(__file__).parent / "../output").resolve()
+
+    with tempfile.TemporaryDirectory(dir=test_output_dir) as output_dir:
+        result = runner.invoke(
+            typer_app,
+            [
+                "transform",
+                str(config_file),
+                "--output-dir",
+                output_dir,
+            ],
+        )
+
+        nodes_output = Path(output_dir) / "protein-links-detailed_nodes.tsv"
+        edges_output = Path(output_dir) / "protein-links-detailed_edges.tsv"
+
+        assert nodes_output.exists()
+        assert edges_output.exists()
+
+        assert result.exit_code == 0

--- a/tests/unit/test_multifile.py
+++ b/tests/unit/test_multifile.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from koza.model.source import Source
 from koza.runner import KozaRunner
 
@@ -8,7 +10,7 @@ def test_multiple_file_source():
 
     assert len(config.reader.files) == 2
 
-    source = Source(config)
+    source = Source(config, base_directory=Path(config_file).parent)
     row_count = len(list(source))
 
     assert row_count == 15
@@ -20,7 +22,7 @@ def test_multiple_file_row_limit():
 
     assert len(config.reader.files) == 2
 
-    source = Source(config, row_limit=2)
+    source = Source(config, base_directory=Path(config_file).parent, row_limit=2)
     row_count = len(list(source))
 
     assert row_count == 2

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -85,7 +86,7 @@ def test_load_config():
         }
     )
 
-    runner = KozaRunner.from_config(config)
+    runner = KozaRunner.from_config(config, base_directory=Path(__file__).parent.parent.parent)
     assert callable(runner.transform)
     assert runner.transform_record is None
     assert callable(runner.run)


### PR DESCRIPTION
This PR changes how path resolution works for transform config files. Previously, Koza would (by convention-- it was not enforced in any way) assume that the working directory where `koza` was called was the root of a Python project. Take the example string ingest for example:

https://github.com/monarch-initiative/koza/blob/ab478940da0014a7aa80ef45e181065f28433e6d/examples/string/protein-links-detailed.yaml#L1-L13

All of those paths rely on being resolved relative to the `./koza/` root directory.

I ran into a problem with this when writing a test for the CLI runner (which this PR also adds). I added a new test at `tests/unit/test_cli_runner.py` and tried to run one of the example transforms, but that changed the working directory to `./koza/tests/unit/`, rather than the required `./koza`. I could have used `os.chdir()` to go to the expected directory, but I thought it might make more sense for paths in yaml to be resolved relative to the yaml file itself. That is what 01a08b0 does.

As a consequence, a koza transform can be run from anywhere, rather than a specific (undocumented) root directory. Here's that same string ingest with these changes:

https://github.com/monarch-initiative/koza/blob/01a08b0b6c27c7c4773421ab9bd64b776da41dba/examples/string/protein-links-detailed.yaml#L1-L13