### PR TITLE
Set jsonlines writer free from dependency on node_properties and edge_properties 

### DIFF
--- a/src/koza/io/writer/jsonl_writer.py
+++ b/src/koza/io/writer/jsonl_writer.py
@@ -21,20 +21,28 @@ class JSONLWriter(KozaWriter):
         self.converter = KGXConverter()
 
         os.makedirs(output_dir, exist_ok=True)
-        if config.node_properties:
-            self.nodeFH = open(f"{output_dir}/{source_name}_nodes.jsonl", "w")
-        if config.edge_properties:
-            self.edgeFH = open(f"{output_dir}/{source_name}_edges.jsonl", "w")
+
+    def _ensure_node_file_handle(self):
+        """Create node file handle if it doesn't exist"""
+        if not hasattr(self, "nodeFH"):
+            self.nodeFH = open(f"{self.output_dir}/{self.source_name}_nodes.jsonl", "w")
+
+    def _ensure_edge_file_handle(self):
+        """Create edge file handle if it doesn't exist"""
+        if not hasattr(self, "edgeFH"):
+            self.edgeFH = open(f"{self.output_dir}/{self.source_name}_edges.jsonl", "w")
 
     def write(self, entities: Iterable):
         (nodes, edges) = self.converter.convert(entities)
 
         if nodes:
+            self._ensure_node_file_handle()
             for n in nodes:
                 node = json.dumps(n, ensure_ascii=False)
                 self.nodeFH.write(node + "\n")
 
         if edges:
+            self._ensure_edge_file_handle()
             for e in edges:
                 if self.sssom_config:
                     e = self.sssom_config.apply_mapping(e)

--- a/tests/unit/test_jsonl_writer_lazy_handles.py
+++ b/tests/unit/test_jsonl_writer_lazy_handles.py
@@ -1,0 +1,49 @@
+import tempfile
+from unittest.mock import mock_open, patch
+
+from biolink_model.datamodel.pydanticmodel_v2 import Disease, Gene, GeneToDiseaseAssociation, KnowledgeLevelEnum, AgentTypeEnum
+
+from koza.io.writer.jsonl_writer import JSONLWriter
+from koza.model.writer import WriterConfig
+
+
+def test_jsonl_writer_lazy_file_handle_creation():
+    """
+    Test that JSONLWriter creates file handles lazily when write() is called,
+    not during __init__, preventing null handle exceptions.
+    """
+    config = WriterConfig()
+    
+    with tempfile.TemporaryDirectory() as temp_dir:
+        writer = JSONLWriter(temp_dir, "test", config)
+        
+        # Verify file handles don't exist after init
+        assert not hasattr(writer, "nodeFH")
+        assert not hasattr(writer, "edgeFH")
+        
+        # Create test entities that will generate both nodes and edges
+        gene = Gene(id="HGNC:11603", symbol="TBX4")
+        disease = Disease(id="MONDO:0005002", name="test disease")
+        association = GeneToDiseaseAssociation(
+            id="uuid:test",
+            subject=gene.id,
+            object=disease.id,
+            predicate="biolink:contributes_to",
+            knowledge_level=KnowledgeLevelEnum.not_provided,
+            agent_type=AgentTypeEnum.not_provided,
+        )
+        
+        entities = [gene, disease, association]
+        
+        # Mock the open function to track file handle creation
+        with patch("builtins.open", mock_open()) as mock_file:
+            writer.write(entities)
+            
+            # Verify file handles were created during write()
+            assert hasattr(writer, "nodeFH")
+            assert hasattr(writer, "edgeFH")
+            
+            # Verify open was called for both node and edge files
+            assert mock_file.call_count == 2
+            mock_file.assert_any_call(f"{temp_dir}/test_nodes.jsonl", "w")
+            mock_file.assert_any_call(f"{temp_dir}/test_edges.jsonl", "w")


### PR DESCRIPTION
This changes how we create the node file handler and edge file handler, rather than depending on node_properties or edge_properties being set in a config as a signal of which files to write, now the file handle gets created when it's needed. 