### PR TITLE
Use json model for model dump in kgx converter for easier serialization

### DIFF
--- a/src/koza/converter/kgx_converter.py
+++ b/src/koza/converter/kgx_converter.py
@@ -42,10 +42,10 @@ class KGXConverter:
 
     def convert_node(self, node) -> dict:
         if isinstance(node, BaseModel):
-            return node.model_dump(mode='json')
+            return node.model_dump(mode='json', exclude_none=True)
         return asdict(node)
 
     def convert_association(self, association) -> dict:
         if isinstance(association, BaseModel):
-            return association.model_dump(mode='json')
+            return association.model_dump(mode='json', exclude_none=True)
         return asdict(association)

--- a/src/koza/converter/kgx_converter.py
+++ b/src/koza/converter/kgx_converter.py
@@ -42,10 +42,10 @@ class KGXConverter:
 
     def convert_node(self, node) -> dict:
         if isinstance(node, BaseModel):
-            return dict(node)
+            return node.model_dump(mode='json')
         return asdict(node)
 
     def convert_association(self, association) -> dict:
         if isinstance(association, BaseModel):
-            return dict(association)
+            return association.model_dump(mode='json')
         return asdict(association)

--- a/tests/unit/test_kgx_converter.py
+++ b/tests/unit/test_kgx_converter.py
@@ -55,7 +55,7 @@ def test_association_conversion():
 )
 def test_keys_uniformity(id, symbol, synonym, xref):
     """
-    Connfirm that the result of the conversion has all of the same fields, even if some aren't used
+    Connfirm that the result of the conversion has the same fields, even if some are empty lists
     """
     gene = Gene(id=id, symbol=symbol, synonym=synonym, xref=xref)
 
@@ -67,5 +67,34 @@ def test_keys_uniformity(id, symbol, synonym, xref):
     assert "symbol" in output.keys()
     assert "synonym" in output.keys()
     assert "xref" in output.keys()
-    assert "description" in output.keys()
-    # assert 'source' in output.keys() ----> Did we remove this?
+    assert "description" not in output.keys()
+
+
+@pytest.mark.parametrize(
+    "id, symbol, synonym, xref",
+    [
+        ("MGI:1917258", None, None, []),
+        ("RGD:620474", "", [], ["ENSEMBL:ENSRNOG00000002607", "NCBI_Gene:140586"]),
+    ],
+)
+def test_exclude_none(id, symbol, synonym, xref):
+    """
+    Connfirm that the result of the conversion has the same fields, even if some are empty lists
+    """
+    gene = Gene(id=id, symbol=symbol, synonym=synonym, xref=xref)
+
+    (nodes, edges) = KGXConverter().convert([gene])
+    output = nodes[0]
+
+    assert output["id"] == "MGI:1917258" or output["id"] == "RGD:620474"
+
+    if output["id"] == "MGI:1917258":
+        assert "symbol" not in output.keys()
+        assert "synonym" not in output.keys()
+    elif output["id"] == "RGD:620474":
+        assert "symbol" in output.keys()
+        assert "synonym" in output.keys()
+
+    assert "category" in output.keys()
+    assert "id" in output.keys()
+    assert "description" not in output.keys()


### PR DESCRIPTION
model_dump when the pydantic values have dates will fail in the writer, because date objects get preserved. model_dump_json works fine, but we want the output of kgx_converter to stay a dict, so it's too soon to produce json (and totally the wrong choice if we're not outputting jsonl!). model_dump(mode='json') does the model dump behavior of model_dump_json, but produces a dict instead. Just what we need. 