### PR TITLE
Fix test_404 by mocking HTTP request

### DIFF
--- a/tests/unit/test_io_utils.py
+++ b/tests/unit/test_io_utils.py
@@ -11,6 +11,7 @@ https://github.com/monarch-initiative/dipper/blob/682560f/tests/test_udp.py#L85
 
 from pathlib import Path
 from tarfile import TarFile
+from unittest.mock import MagicMock, patch
 from zipfile import ZipFile
 
 import pytest
@@ -20,9 +21,15 @@ from koza.io.utils import _sanitize_export_property
 
 
 def test_404():
-    resource = "http://httpstat.us/404"
-    with pytest.raises(ValueError):
-        io_utils.open_resource(resource)
+    """Test that open_resource raises ValueError for HTTP 404 responses."""
+    # Mock the requests.get call to return a 404 status
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.text = "Not Found"
+
+    with patch("koza.io.utils.requests.get", return_value=mock_response):
+        with pytest.raises(ValueError, match="Remote file returned 404"):
+            io_utils.open_resource("http://example.com/nonexistent")
 
 
 def test_http():


### PR DESCRIPTION
## Summary
Fix failing test by replacing actual HTTP request with mocked version

## Changes
- Replace actual HTTP request to `httpstat.us/404` with mocked `requests.get` call
- Add `unittest.mock` imports for `MagicMock` and `patch`
- Use proper error message matching in pytest assertion
- Make test more reliable by removing external service dependency

## Test plan
- [x] Run `poetry run python -m pytest tests/unit/test_io_utils.py::test_404 -v` - passes
- [x] Verify test no longer makes external HTTP requests
- [x] Confirm test still validates the ValueError is raised for 404 responses

🤖 Generated with [Claude Code](https://claude.ai/code)