### PR TITLE
Flatten JSONL array columns for force-single-valued fields during merge

### DIFF
--- a/src/koza/graph_operations/utils.py
+++ b/src/koza/graph_operations/utils.py
@@ -16,7 +16,7 @@ from koza.model.graph_operations import (
     KGXFormat,
     OperationSummary,
 )
-from koza.graph_operations.schema_utils import get_multivalued_columns
+from koza.graph_operations.schema_utils import get_multivalued_columns, FORCE_SINGLE_VALUED_FIELDS
 
 
 def _generate_multivalued_select(
@@ -41,7 +41,15 @@ def _generate_multivalued_select(
     # Build SELECT clause with conditional column transformation
     select_parts = []
     for col_name, col_type, *_ in columns_result:
-        if col_name in multivalued_columns and col_type == "VARCHAR":
+        if col_name in FORCE_SINGLE_VALUED_FIELDS and col_type == "VARCHAR[]":
+            # Flatten array to single value for fields forced to be single-valued
+            # (e.g., JSONL has category as ["biolink:X"] but we need it as "biolink:X")
+            select_parts.append(f"""
+                CASE
+                    WHEN "{col_name}" IS NULL OR len("{col_name}") = 0 THEN NULL
+                    ELSE "{col_name}"[1]
+                END as "{col_name}" """.strip())
+        elif col_name in multivalued_columns and col_type == "VARCHAR":
             # Split pipe-delimited values into arrays, handle empty/null values
             select_parts.append(f"""
                 CASE
@@ -256,7 +264,8 @@ class GraphDatabase:
 
     def _transform_multivalued_columns(self, temp_table_name: str, skip_columns: set[str] | None = None):
         """
-        Transform pipe-delimited VARCHAR columns to VARCHAR[] arrays for known multivalued fields.
+        Transform pipe-delimited VARCHAR columns to VARCHAR[] arrays for known multivalued fields,
+        and flatten VARCHAR[] columns to VARCHAR for force-single-valued fields (e.g. from JSONL input).
 
         Args:
             temp_table_name: Name of the temporary table to transform
@@ -265,14 +274,21 @@ class GraphDatabase:
         skip_columns = skip_columns or set()
 
         try:
-            # Get column names from the temp table
+            # Get column info from the temp table
             describe_result = self.conn.execute(f"DESCRIBE {temp_table_name}").fetchall()
             column_names = [row[0] for row in describe_result if row[0] not in skip_columns]
+            column_types = {row[0]: row[1] for row in describe_result if row[0] not in skip_columns}
 
             # Identify which columns are multivalued
             multivalued_cols = get_multivalued_columns(column_names)
 
-            if not multivalued_cols:
+            # Check if any force-single-valued fields arrived as arrays (e.g. from JSONL)
+            needs_flattening = any(
+                col in FORCE_SINGLE_VALUED_FIELDS and column_types.get(col) == "VARCHAR[]"
+                for col in column_names
+            )
+
+            if not multivalued_cols and not needs_flattening:
                 return
 
             # Generate SELECT with transformations


### PR DESCRIPTION
## Summary

- When merging JSONL and TSV files, fields like `category` have mismatched DuckDB types: JSONL produces `VARCHAR[]` (native JSON arrays) while TSV produces `VARCHAR` (plain strings). This causes `UNION ALL BY NAME` to fail with a conversion error.
- Adds flattening in `_generate_multivalued_select()` for `FORCE_SINGLE_VALUED_FIELDS` (`category`, `in_taxon`, `type`) that arrive as `VARCHAR[]` — takes the first element to produce a scalar `VARCHAR`
- Updates the early-return guard in `_transform_multivalued_columns()` so the transform runs even when there are no pipe-delimited columns to expand but there are arrays to flatten

## Context

This was discovered when adding dismech (which publishes JSONL edge files) to monarch-ingest. The merge step failed with:

```
Conversion Error: Type VARCHAR with value 'biolink:GeneToPhenotypicFeatureAssociation' 
can't be cast to the destination type VARCHAR[]
```

## Test plan

- [x] Existing `test_join.py` multivalued field tests still pass (37/37)
- [ ] Integration test with mixed TSV + JSONL merge in monarch-ingest