### PR TITLE
Add FORCE_MULTIVALUED_FIELDS override for subsets

### DIFF
--- a/src/koza/graph_operations/schema_utils.py
+++ b/src/koza/graph_operations/schema_utils.py
@@ -85,6 +85,14 @@ FORCE_SINGLE_VALUED_FIELDS: Set[str] = {
     "type",
 }
 
+# Fields that should be treated as multivalued regardless of schema definition.
+# Use this for KGX/OBO conventions that the reference schema (Biolink Model) does not define.
+# Without this override, pipe-delimited values land in downstream tables as a single VARCHAR
+# with literal '|' characters instead of being split into a VARCHAR[] array.
+FORCE_MULTIVALUED_FIELDS: Set[str] = {
+    "subsets",
+}
+
 # Fallback multivalued fields for KGX format (used only when schema unavailable)
 KGX_MULTIVALUED_FIELDS_FALLBACK: Set[str] = {
     # Node properties
@@ -149,6 +157,10 @@ def is_field_multivalued(field_name: str, schema_path: Optional[str] = None) -> 
     # Check if field is forced to be single-valued
     if field_name in FORCE_SINGLE_VALUED_FIELDS:
         return False
+
+    # Check if field is forced to be multivalued (overrides schema)
+    if field_name in FORCE_MULTIVALUED_FIELDS:
+        return True
 
     # Try to get from schema first
     parser = get_schema_parser(schema_path)

--- a/tests/test_schema_utils.py
+++ b/tests/test_schema_utils.py
@@ -1,0 +1,31 @@
+"""
+Tests for koza.graph_operations.schema_utils — multivalued field detection.
+"""
+
+from koza.graph_operations.schema_utils import (
+    FORCE_MULTIVALUED_FIELDS,
+    FORCE_SINGLE_VALUED_FIELDS,
+    is_field_multivalued,
+)
+
+
+def test_force_single_valued_overrides_schema():
+    # `category` is multivalued in Biolink Model but we treat it as single-valued
+    assert "category" in FORCE_SINGLE_VALUED_FIELDS
+    assert is_field_multivalued("category") is False
+
+
+def test_force_multivalued_overrides_schema():
+    # `subsets` is not defined in Biolink Model on named_thing/association,
+    # so the schema lookup returns False. The override forces True.
+    assert "subsets" in FORCE_MULTIVALUED_FIELDS
+    assert is_field_multivalued("subsets") is True
+
+
+def test_biolink_multivalued_field_detected():
+    # Sanity check that schema-driven detection still works
+    assert is_field_multivalued("xref") is True
+
+
+def test_unknown_field_is_not_multivalued():
+    assert is_field_multivalued("definitely_not_a_real_slot_xyz") is False


### PR DESCRIPTION
## Summary

- Adds `FORCE_MULTIVALUED_FIELDS` set to `schema_utils.py`, mirroring the existing `FORCE_SINGLE_VALUED_FIELDS` pattern.
- Includes `subsets` as the first entry.
- Adds a small test module (`tests/test_schema_utils.py`) covering the override paths and a couple of regression cases.

## Context

The schema-driven multivalued lookup uses Biolink Model, which does not define a `subsets` slot on `named thing`/`association` (or anywhere else). As a result, pipe-delimited `subsets` values from KGX TSVs landed in downstream DuckDB tables as a single `VARCHAR` containing literal `|` characters, rather than being split into `VARCHAR[]`. Downstream consumers that expect arrays (e.g. Solr loading via JSON) then stored a one-element array containing the pipe string.

`subsets` is a standard OBO/ontology concept, so the long-term fix is in Biolink Model itself. This override unblocks consumers in the meantime, and matches the existing pattern used for `category`/`in_taxon`/`type` going the other direction.

## Test plan

- [x] `pytest tests/test_schema_utils.py` — 4 tests, all pass
- [ ] Verify end-to-end via monarch-ingest branch dependency on this PR (rebuild `denormalized_nodes`, reload Solr entity core, confirm `subsets` lands as a real array)