### PR TITLE
perf: stop over-feeding GRAPE in connectivity reports

### DIFF
--- a/src/koza/graph_operations/connectivity.py
+++ b/src/koza/graph_operations/connectivity.py
@@ -459,9 +459,16 @@ def _build_connectivity_summary(
     graph,
     config: ConnectivityReportConfig,
 ) -> ConnectivitySummary:
-    """Construct a ``ConnectivitySummary`` from the DuckDB sidecar tables."""
-    num_nodes = graph.get_number_of_nodes()
-    num_edges = graph.get_number_of_edges()
+    """Construct a ``ConnectivitySummary`` from the DuckDB sidecar tables.
+
+    Node and edge counts are sourced from DuckDB, not GRAPE. GRAPE collapses
+    edges to its topological skeleton (unique unordered SO-pairs in undirected
+    mode, or unique SPO triples if an edge_type_column is passed), which is an
+    implementation detail of CC. The property-graph row counts are what users
+    care about.
+    """
+    num_nodes = db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+    num_edges = db.conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
 
     comp_row = db.conn.execute(
         """

--- a/src/koza/model/graph_operations.py
+++ b/src/koza/model/graph_operations.py
@@ -811,10 +811,10 @@ class ConnectivityReportConfig(BaseModel):
     output_file: Path | None = None  # YAML summary file
     graph_name: str = "KnowledgeGraph"
     node_name_column: str = "id"
-    node_type_column: str | None = "category"
+    node_type_column: str | None = None
     edge_src_column: str = "subject"
     edge_dst_column: str = "object"
-    edge_type_column: str | None = "predicate"
+    edge_type_column: str | None = None
     directed: bool = False  # Undirected for connectivity analysis
     top_components: int = 20  # Number of top minor components to include in summary
     quiet: bool = False


### PR DESCRIPTION
## Summary

- Default `ConnectivityReportConfig.node_type_column` and `.edge_type_column` to `None`. GRAPE's CC algorithm (`get_node_connected_component_ids`) is purely topological — node/edge types were being materialized into the pandas DataFrame that `Graph.from_pd` consumes, and then discarded. The knobs remain available for callers that want type-aware GRAPE behavior.
- Source `num_nodes` / `num_edges` for the connectivity summary from DuckDB rather than from GRAPE. GRAPE collapses to its topological skeleton (unique SO-pairs undirected, or SPO triples if `edge_type_column` is passed), which is meaningless for a property-graph data model — rows differing in `publications` / `sources[]` / `qualifier` / `knowledge_level` are genuinely distinct edges. This eliminates the silent edge-count shrinkage between `graph-stats` and `connectivity` outputs.

## Impact (translator-kg, 1.7M nodes / 29.4M edges)

| Metric | Before | After | Δ |
|---|---|---|---|
| `koza report connectivity` wall | 70.4 s | 44.0 s | **-37%** |
| Peak RSS | 17.2 GB | 12.4 GB | **-28%** |
| Component topology | — | unchanged | — |

## Test plan

- [x] Existing connectivity tests pass (363 / 363)
- [x] Translator-kg end-to-end run — same CC counts, lower memory
- [ ] Reviewer sanity-check: confirm there is no caller that depends on `node_type_column` / `edge_type_column` defaulting to `"category"` / `"predicate"`