### PR TITLE
feat: explicit JSONL schema via --slots-file

### DIFF
--- a/src/koza/graph_operations/graph_schema.py
+++ b/src/koza/graph_operations/graph_schema.py
@@ -380,6 +380,160 @@ def _duckdb_type_for(slot_def: SlotDefinition | None) -> str:
     return "VARCHAR"
 
 
+# Biolink ranges that map to non-string DuckDB scalar types. Anything not
+# listed here defaults to VARCHAR (covers string, uriorcurie, label_type,
+# narrative_text, all enums, all class CURIE references, etc.).
+_RANGE_TO_DUCKDB_SCALAR: dict[str, str] = {
+    "integer": "BIGINT",
+    "float": "DOUBLE",
+    "double": "DOUBLE",
+    "boolean": "BOOLEAN",
+}
+
+# Biolink ranges treated as "primitive" for the purpose of multivalued
+# dispatch: their multivalued form is a list of scalars in JSONL, never a
+# list of struct objects. Class-typed multivalued slots are dispatched via
+# the inlined / inlined_as_list LinkML flags instead.
+_PRIMITIVE_RANGE_NAMES: frozenset[str] = frozenset(
+    {
+        "string",
+        "uriorcurie",
+        "iri type",
+        "iriortext",
+        "label type",
+        "narrative text",
+        "symbol type",
+        "chemical formula value",
+        "biological sequence",
+        "date",
+        "datetime",
+        "time",
+    }
+)
+
+
+def _scalar_for_range(rng: str) -> str:
+    return _RANGE_TO_DUCKDB_SCALAR.get(rng, "VARCHAR")
+
+
+def _duckdb_type_for_class(sv: SchemaView, class_name: str, depth: int = 0, max_depth: int = 2) -> str:
+    """Build a DuckDB STRUCT(...) type for a Biolink class's induced slots.
+
+    Recursive for nested class-typed slots that are `inlined_as_list`, bounded
+    by `max_depth`. Returns `JSON` when depth is exceeded or the class is
+    unknown — a safe fallback that preserves the literal value.
+    """
+    if depth > max_depth:
+        return "JSON"
+    try:
+        slots = sv.class_induced_slots(class_name)
+    except Exception:
+        return "JSON"
+    fields: list[tuple[str, str]] = []
+    for s in slots:
+        col = _snake_case(s.name)
+        rng = str(s.range) if s.range else "string"
+        if rng in _PRIMITIVE_RANGE_NAMES or rng in _RANGE_TO_DUCKDB_SCALAR:
+            scalar = _scalar_for_range(rng)
+            inner = f"{scalar}[]" if s.multivalued else scalar
+        elif s.multivalued and s.inlined_as_list:
+            inner = f"{_duckdb_type_for_class(sv, rng, depth + 1, max_depth)}[]"
+        elif s.multivalued and s.inlined:
+            struct = _duckdb_type_for_class(sv, rng, depth + 1, max_depth)
+            inner = f"MAP(VARCHAR, {struct})" if struct != "JSON" else "JSON"
+        elif s.multivalued:
+            inner = "VARCHAR[]"  # list of CURIE references
+        else:
+            inner = "VARCHAR"  # scalar CURIE reference
+        fields.append((col, inner))
+    fields_sql = ", ".join(f'"{n}" {t}' for n, t in fields)
+    return f"STRUCT({fields_sql})"
+
+
+def duckdb_columns_for_slots(
+    slots: list[str],
+    root_class: str,
+    biolink_schemaview: SchemaView,
+    declared_outputs: dict[str, dict] | None = None,
+    strict: bool = True,
+) -> dict[str, str]:
+    """Map a list of slot names to DuckDB column types, dispatched on Biolink.
+
+    Returned dict is suitable for DuckDB's `read_json(..., columns={...})`
+    parameter — bypasses schema inference entirely for JSONL files where we
+    already know the slot set.
+
+    Type dispatch follows LinkML semantics:
+
+    | LinkML flags                                | DuckDB type             |
+    |---------------------------------------------|-------------------------|
+    | primitive range, scalar                     | `<scalar>` (VARCHAR/…)  |
+    | primitive range, multivalued                | `<scalar>[]`            |
+    | class range, scalar                         | `VARCHAR` (CURIE ref)   |
+    | class range, multivalued + inlined_as_list  | `STRUCT(...)[]`         |
+    | class range, multivalued + inlined          | `MAP(VARCHAR, STRUCT)`  |
+    | class range, multivalued, neither flag      | `VARCHAR[]` (refs)      |
+
+    `root_class` is the Biolink class to use as context for `induced_slot`
+    lookups — `ENTITY_ROOT` for node files, `ASSOCIATION_ROOT` for edge files.
+
+    With `strict=True` (default), slots that match no Biolink slot, no koza
+    extra, and no declared output raise `UnknownSlotsError` — the ADR-0001
+    contract applied to JSONL input. With `strict=False`, unknown slots map
+    to `VARCHAR` so the loader can still read whatever's in the file.
+    """
+    declared_outputs = declared_outputs or {}
+    pool = _biolink_slot_pool(biolink_schemaview, root_class)
+
+    columns: dict[str, str] = {}
+    rejected: list[str] = []
+    for slot in slots:
+        if slot in declared_outputs:
+            spec = declared_outputs[slot]
+            rng = spec.get("range", "string")
+            mv = bool(spec.get("multivalued"))
+            scalar = _scalar_for_range(rng)
+            columns[slot] = f"{scalar}[]" if mv else scalar
+            continue
+        if slot in KOZA_INGEST_EXTRAS:
+            spec = KOZA_INGEST_EXTRAS[slot]
+            columns[slot] = _scalar_for_range(spec.get("range", "string"))
+            continue
+        if slot not in pool:
+            rejected.append(slot)
+            continue
+        try:
+            s = biolink_schemaview.induced_slot(slot.replace("_", " "), root_class)
+        except Exception:
+            columns[slot] = "VARCHAR"
+            continue
+        rng = str(s.range) if s.range else "string"
+        if rng in _PRIMITIVE_RANGE_NAMES or rng in _RANGE_TO_DUCKDB_SCALAR:
+            scalar = _scalar_for_range(rng)
+            columns[slot] = f"{scalar}[]" if s.multivalued else scalar
+        elif not s.multivalued:
+            columns[slot] = "VARCHAR"  # scalar CURIE reference to a class instance
+        elif s.inlined_as_list:
+            columns[slot] = f"{_duckdb_type_for_class(biolink_schemaview, rng)}[]"
+        elif s.inlined:
+            struct = _duckdb_type_for_class(biolink_schemaview, rng)
+            columns[slot] = f"MAP(VARCHAR, {struct})" if struct != "JSON" else "JSON"
+        else:
+            columns[slot] = "VARCHAR[]"  # multivalued CURIE references
+
+    if rejected:
+        if strict:
+            details = ", ".join(rejected)
+            raise UnknownSlotsError(
+                f"{len(rejected)} slot(s) match no Biolink slot, koza extra, or "
+                f"declared output for root class {root_class!r}: {details}"
+            )
+        for slot in rejected:
+            columns[slot] = "VARCHAR"
+
+    return columns
+
+
 def ensure_slots(
     conn: duckdb.DuckDBPyConnection, table: str, slot_names: list[str]
 ) -> None:

--- a/src/koza/graph_operations/join.py
+++ b/src/koza/graph_operations/join.py
@@ -6,6 +6,7 @@ import re
 import time
 from pathlib import Path
 
+import yaml
 from loguru import logger
 from tqdm import tqdm
 
@@ -243,23 +244,46 @@ def _apply_slots_file(config: JoinConfig) -> None:
     Both keys are optional. Files whose file_type is missing or doesn't match
     a slot list are left untouched (no implicit assumption that an unlabeled
     file is one or the other).
-    """
-    import yaml
 
+    Note: any JSONL key not in the slot list is silently dropped by
+    `read_json(columns=...)`. An under-specified slots_file therefore drops
+    data without warning — by design (the slot list is the user's contract)
+    but worth knowing.
+    """
     if config.slots_file is None:
         return
     with config.slots_file.open() as f:
         loaded = yaml.safe_load(f) or {}
-    node_slots = loaded.get("nodes") or None
-    edge_slots = loaded.get("edges") or None
+    if not isinstance(loaded, dict):
+        raise ValueError(
+            f"slots_file {config.slots_file} must be a mapping with "
+            f"'nodes' and/or 'edges' keys, got {type(loaded).__name__}"
+        )
+    node_slots = _validated_slot_list(loaded, "nodes", config.slots_file)
+    edge_slots = _validated_slot_list(loaded, "edges", config.slots_file)
 
-    from koza.model.graph_operations import KGXFileType
     for spec in config.node_files:
         if spec.file_type == KGXFileType.NODES and node_slots and spec.slots is None:
             spec.slots = list(node_slots)
     for spec in config.edge_files:
         if spec.file_type == KGXFileType.EDGES and edge_slots and spec.slots is None:
             spec.slots = list(edge_slots)
+
+
+def _validated_slot_list(loaded: dict, key: str, source: Path) -> list[str] | None:
+    """Return loaded[key] as a list of strings, or None if missing/empty.
+
+    Raises ValueError with a pointer to the offending file when the value is
+    present but not shaped as `list[str]`.
+    """
+    value = loaded.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, list) or not all(isinstance(s, str) for s in value):
+        raise ValueError(
+            f"slots_file {source}: {key!r} must be a list of strings"
+        )
+    return value or None
 
 
 def _seed_graph_schema(db: GraphDatabase, files_loaded: list[FileLoadResult]) -> None:

--- a/src/koza/graph_operations/join.py
+++ b/src/koza/graph_operations/join.py
@@ -123,6 +123,13 @@ def join_graphs(config: JoinConfig) -> JoinResult:
     files_loaded: list[FileLoadResult] = []
 
     try:
+        # Apply slots_file (if any) to each FileSpec by file_type. Mutates
+        # the FileSpec.slots field so downstream read_json gets the explicit
+        # columns clause and skips schema inference. See
+        # decisions/0001-graph-schema-strict-derivation.md.
+        if config.slots_file is not None:
+            _apply_slots_file(config)
+
         # Initialize database
         with GraphDatabase(config.database_path) as db:
             # Load node files
@@ -223,6 +230,36 @@ def join_graphs(config: JoinConfig) -> JoinResult:
             print_operation_summary(summary)
 
         raise
+
+
+def _apply_slots_file(config: JoinConfig) -> None:
+    """Read JoinConfig.slots_file and populate FileSpec.slots for each input.
+
+    The yaml shape is:
+
+        nodes: [id, category, name, ...]
+        edges: [id, subject, predicate, object, sources, ...]
+
+    Both keys are optional. Files whose file_type is missing or doesn't match
+    a slot list are left untouched (no implicit assumption that an unlabeled
+    file is one or the other).
+    """
+    import yaml
+
+    if config.slots_file is None:
+        return
+    with config.slots_file.open() as f:
+        loaded = yaml.safe_load(f) or {}
+    node_slots = loaded.get("nodes") or None
+    edge_slots = loaded.get("edges") or None
+
+    from koza.model.graph_operations import KGXFileType
+    for spec in config.node_files:
+        if spec.file_type == KGXFileType.NODES and node_slots and spec.slots is None:
+            spec.slots = list(node_slots)
+    for spec in config.edge_files:
+        if spec.file_type == KGXFileType.EDGES and edge_slots and spec.slots is None:
+            spec.slots = list(edge_slots)
 
 
 def _seed_graph_schema(db: GraphDatabase, files_loaded: list[FileLoadResult]) -> None:

--- a/src/koza/graph_operations/utils.py
+++ b/src/koza/graph_operations/utils.py
@@ -2,6 +2,7 @@
 Shared utilities for graph operations using DuckDB.
 """
 
+import re
 import time
 from pathlib import Path
 
@@ -90,6 +91,9 @@ def _build_injected_columns_exclude(
     return f" EXCLUDE ({', '.join(sorted(present))})"
 
 
+_SLOT_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
 def _jsonl_explicit_columns_clause(file_spec: FileSpec) -> str | None:
     """Build a `columns={...}` clause from file_spec.slots for JSONL.
 
@@ -119,6 +123,17 @@ def _jsonl_explicit_columns_clause(file_spec: FileSpec) -> str | None:
         biolink_schemaview=load_biolink_schemaview(),
         declared_outputs=declared_outputs,
     )
+    # Guard against SQL injection at the emitter rather than relying on
+    # upstream validation. In the strict-reject path slot names come from
+    # the Biolink pool / KOZA_INGEST_EXTRAS / declared_outputs and are
+    # already constrained, but a permissive caller could supply arbitrary
+    # identifiers.
+    for slot_name in cols:
+        if not _SLOT_NAME_RE.fullmatch(slot_name):
+            raise ValueError(
+                f"slot name {slot_name!r} contains characters disallowed in a "
+                f"DuckDB identifier; refusing to interpolate into SQL"
+            )
     return "{" + ", ".join(f"'{k}': '{v}'" for k, v in cols.items()) + "}"
 
 

--- a/src/koza/graph_operations/utils.py
+++ b/src/koza/graph_operations/utils.py
@@ -90,13 +90,46 @@ def _build_injected_columns_exclude(
     return f" EXCLUDE ({', '.join(sorted(present))})"
 
 
+def _jsonl_explicit_columns_clause(file_spec: FileSpec) -> str | None:
+    """Build a `columns={...}` clause from file_spec.slots for JSONL.
+
+    Returns None when no slots are specified — caller falls back to schema
+    inference. Imports are local to avoid pulling biolink into the import
+    graph for the no-slots path.
+    """
+    if not file_spec.slots:
+        return None
+    from .graph_schema import (
+        ASSOCIATION_ROOT,
+        ENTITY_ROOT,
+        discover_declared_outputs,
+        duckdb_columns_for_slots,
+        load_biolink_schemaview,
+    )
+    root_class = (
+        ASSOCIATION_ROOT
+        if file_spec.file_type == KGXFileType.EDGES
+        else ENTITY_ROOT
+    )
+    class_label = "Association" if file_spec.file_type == KGXFileType.EDGES else "Entity"
+    declared_outputs = discover_declared_outputs().get(class_label, {})
+    cols = duckdb_columns_for_slots(
+        slots=list(file_spec.slots),
+        root_class=root_class,
+        biolink_schemaview=load_biolink_schemaview(),
+        declared_outputs=declared_outputs,
+    )
+    return "{" + ", ".join(f"'{k}': '{v}'" for k, v in cols.items()) + "}"
+
+
 def get_duckdb_read_statement(file_spec: FileSpec, sample_size: int | None = None) -> str:
     """
     Generate DuckDB read statement for the given file spec.
 
     Args:
         file_spec: FileSpec with path and format information
-        sample_size: Optional sample size for JSONL schema inference (-1 for full scan)
+        sample_size: Optional sample size for JSONL schema inference (-1 for full scan).
+            Ignored when file_spec.slots is set (explicit schema bypasses inference).
 
     Returns:
         DuckDB read statement string
@@ -108,6 +141,13 @@ def get_duckdb_read_statement(file_spec: FileSpec, sample_size: int | None = Non
         return f"read_csv('{file_path_str}', delim='\\t', header=true, all_varchar=true)"
     elif format_type == KGXFormat.JSONL:
         # convert_strings_to_integers=false prevents DuckDB from inferring UUID-like strings as INT128
+        columns_clause = _jsonl_explicit_columns_clause(file_spec)
+        if columns_clause is not None:
+            # Explicit schema: skip inference entirely. sample_size is moot.
+            return (
+                f"read_json('{file_path_str}', columns={columns_clause}, "
+                f"format='newline_delimited', convert_strings_to_integers=false)"
+            )
         if sample_size is not None:
             return f"read_json('{file_path_str}', format='newline_delimited', convert_strings_to_integers=false, sample_size={sample_size})"
         return f"read_json('{file_path_str}', format='newline_delimited', convert_strings_to_integers=false)"
@@ -234,11 +274,15 @@ class GraphDatabase:
                     raise
 
             # Transform pipe-delimited multivalued fields to arrays
-            # Skip file_source and provided_by (when generated) since we add them as literals
-            skip_columns = {"file_source"}
-            if generate_provided_by:
-                skip_columns.add("provided_by")
-            self._transform_multivalued_columns(temp_table_name, skip_columns=skip_columns)
+            # Skip file_source and provided_by (when generated) since we add them as literals.
+            # When the user supplied explicit slots, the column types already reflect
+            # Biolink's multivalued declarations; the FORCE_SINGLE_VALUED flatten path
+            # would undo that, so skip the transform entirely.
+            if not file_spec.slots:
+                skip_columns = {"file_source"}
+                if generate_provided_by:
+                    skip_columns.add("provided_by")
+                self._transform_multivalued_columns(temp_table_name, skip_columns=skip_columns)
 
             # Get record count
             count_result = self.conn.execute(f"SELECT COUNT(*) FROM {temp_table_name}").fetchone()
@@ -264,6 +308,11 @@ class GraphDatabase:
             )
 
         except Exception as e:
+            # Strict-reject contract from ADR-0001 — propagate, do not swallow.
+            from .graph_schema import UnknownSlotsError
+            if isinstance(e, UnknownSlotsError):
+                raise
+
             load_time = time.time() - start_time
             error_msg = f"Failed to load {file_spec.path}: {e}"
             errors.append(error_msg)

--- a/src/koza/main.py
+++ b/src/koza/main.py
@@ -331,6 +331,10 @@ def join(
         list[str] | None,
         typer.Option("--required-edge-field", help="Edge fields that must be present and non-empty (can specify multiple)"),
     ] = None,
+    slots_file: Annotated[
+        str | None,
+        typer.Option("--slots-file", help="YAML file with {nodes: [...], edges: [...]} — sets explicit JSONL schema, skipping inference"),
+    ] = None,
     quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress output")] = False,
     show_progress: Annotated[bool, typer.Option("--progress", "-p", help="Show progress bars")] = True,
 ) -> None:
@@ -405,6 +409,7 @@ def join(
             schema_reporting=schema_reporting,
             required_node_fields=required_node_fields or [],
             required_edge_fields=required_edge_fields or [],
+            slots_file=Path(slots_file) if slots_file else None,
             quiet=quiet,
             show_progress=show_progress,
         )

--- a/src/koza/main.py
+++ b/src/koza/main.py
@@ -333,7 +333,14 @@ def join(
     ] = None,
     slots_file: Annotated[
         str | None,
-        typer.Option("--slots-file", help="YAML file with {nodes: [...], edges: [...]} — sets explicit JSONL schema, skipping inference"),
+        typer.Option(
+            "--slots-file",
+            help=(
+                "YAML file with {nodes: [...], edges: [...]} — sets explicit JSONL "
+                "schema, skipping inference. JSON keys NOT in the slot list are "
+                "silently dropped at read time."
+            ),
+        ),
     ] = None,
     quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress output")] = False,
     show_progress: Annotated[bool, typer.Option("--progress", "-p", help="Show progress bars")] = True,

--- a/src/koza/model/graph_operations.py
+++ b/src/koza/model/graph_operations.py
@@ -31,6 +31,7 @@ class FileSpec(BaseModel):
     source_name: str | None = Field(default=None,validate_default=True)
     format: KGXFormat | None = Field(default=None,validate_default=True)
     file_type: KGXFileType | None = Field(default=None,validate_default=True)
+    slots: list[str] | None = None  # If set, read only these slots with explicit DuckDB types (skips JSONL schema inference)
 
     @field_validator("format",mode="before")
     def generate_format(cls, format_value :KGXFormat|None, info:ValidationInfo) -> KGXFormat:
@@ -107,6 +108,7 @@ class JoinConfig(GraphOperationConfig):
     required_node_fields: list[str] = Field(default_factory=list)
     required_edge_fields: list[str] = Field(default_factory=list)
     seed_schema: bool = True  # Seed the koza graph schema (derived-schema.yaml + Biolink) into DuckDB metadata
+    slots_file: Path | None = None  # YAML file with {nodes: [...], edges: [...]} — applies explicit JSONL schemas to all files in the join
 
     @model_validator(mode="after")
     def set_database_path_from_output_database(self):

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -14,10 +14,13 @@ from linkml_runtime.utils.schemaview import SchemaView
 
 from koza.graph_operations import prune_graph
 from koza.graph_operations.graph_schema import (
+    ASSOCIATION_ROOT,
+    ENTITY_ROOT,
     UnknownSlotsError,
     current_schema,
     derive_schema,
     discover_declared_outputs,
+    duckdb_columns_for_slots,
     ensure_slots,
     seed_schema,
     stored_biolink_yaml,
@@ -302,3 +305,106 @@ def test_prune_against_seeded_database(biolink_schemaview, tmp_path):
         "phenotype_links": 1,
     }
     assert result.final_stats.edges == 1
+
+
+# ---------------------------------------------------------------------------
+# duckdb_columns_for_slots — LinkML-flag dispatch for explicit-schema JSONL.
+# ---------------------------------------------------------------------------
+
+
+def test_columns_for_primitive_scalar_slot(biolink_schemaview):
+    cols = duckdb_columns_for_slots(["id", "name"], ENTITY_ROOT, biolink_schemaview)
+    assert cols == {"id": "VARCHAR", "name": "VARCHAR"}
+
+
+def test_columns_for_multivalued_primitive_slot(biolink_schemaview):
+    # `category` is multivalued with range=uriorcurie (primitive) → VARCHAR[].
+    cols = duckdb_columns_for_slots(["category"], ENTITY_ROOT, biolink_schemaview)
+    assert cols == {"category": "VARCHAR[]"}
+
+
+def test_columns_for_numeric_and_boolean_slots(biolink_schemaview):
+    cols = duckdb_columns_for_slots(
+        ["p_value", "evidence_count", "negated"],
+        ASSOCIATION_ROOT,
+        biolink_schemaview,
+    )
+    assert cols == {
+        "p_value": "DOUBLE",
+        "evidence_count": "BIGINT",
+        "negated": "BOOLEAN",
+    }
+
+
+def test_columns_for_class_ref_scalar_slot(biolink_schemaview):
+    # `subject` has class range (named thing) and is scalar → CURIE reference → VARCHAR.
+    cols = duckdb_columns_for_slots(["subject"], ASSOCIATION_ROOT, biolink_schemaview)
+    assert cols == {"subject": "VARCHAR"}
+
+
+def test_columns_for_inlined_as_list_class_slot_uses_struct_array(biolink_schemaview):
+    # `sources` is multivalued + inlined_as_list=True → STRUCT(...)[].
+    cols = duckdb_columns_for_slots(["sources"], ASSOCIATION_ROOT, biolink_schemaview)
+    t = cols["sources"]
+    assert t.startswith("STRUCT(") and t.endswith(")[]")
+    assert "resource_id" in t
+    assert "resource_role" in t
+
+
+def test_columns_for_inlined_class_slot_uses_map(biolink_schemaview):
+    # `has_supporting_studies` is multivalued + inlined=True (no inlined_as_list)
+    # → dict-keyed-by-id → MAP(VARCHAR, STRUCT(...)).
+    cols = duckdb_columns_for_slots(
+        ["has_supporting_studies"], ASSOCIATION_ROOT, biolink_schemaview
+    )
+    t = cols["has_supporting_studies"]
+    assert t.startswith("MAP(VARCHAR, STRUCT(") and t.endswith("))")
+
+
+def test_columns_for_multivalued_curie_refs(biolink_schemaview):
+    # `publications` is multivalued with class range but neither inlined flag
+    # set → list of CURIE references → VARCHAR[].
+    cols = duckdb_columns_for_slots(
+        ["publications"], ASSOCIATION_ROOT, biolink_schemaview
+    )
+    assert cols == {"publications": "VARCHAR[]"}
+
+
+def test_columns_for_koza_extras_resolve_without_biolink(biolink_schemaview):
+    cols = duckdb_columns_for_slots(
+        ["file_source", "provided_by"], ENTITY_ROOT, biolink_schemaview
+    )
+    assert cols == {"file_source": "VARCHAR", "provided_by": "VARCHAR"}
+
+
+def test_columns_for_declared_outputs(biolink_schemaview):
+    cols = duckdb_columns_for_slots(
+        ["mapping_source"],
+        ASSOCIATION_ROOT,
+        biolink_schemaview,
+        declared_outputs={
+            "mapping_source": {
+                "description": "SSSOM mapping provenance.",
+                "range": "string",
+                "multivalued": False,
+            },
+        },
+    )
+    assert cols == {"mapping_source": "VARCHAR"}
+
+
+def test_columns_strict_rejects_unknown_slot(biolink_schemaview):
+    with pytest.raises(UnknownSlotsError, match="not_a_real_biolink_slot"):
+        duckdb_columns_for_slots(
+            ["id", "not_a_real_biolink_slot"], ENTITY_ROOT, biolink_schemaview
+        )
+
+
+def test_columns_permissive_admits_unknown_as_varchar(biolink_schemaview):
+    cols = duckdb_columns_for_slots(
+        ["id", "not_a_real_biolink_slot"],
+        ENTITY_ROOT,
+        biolink_schemaview,
+        strict=False,
+    )
+    assert cols == {"id": "VARCHAR", "not_a_real_biolink_slot": "VARCHAR"}

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -1134,6 +1134,105 @@ class TestSlotsFile:
         with pytest.raises(UnknownSlotsError, match="not_a_biolink_slot"):
             join_graphs(config)
 
+    def test_slots_file_subset_drops_unmentioned_keys(self, nested_edges_jsonl, temp_dir):
+        """By design, read_json(columns=...) silently drops JSON keys not in
+        the slot list. Locked in as a regression marker — if behavior ever
+        changes, the docstring on _apply_slots_file needs updating too."""
+        import duckdb
+
+        slots_file = temp_dir / "slots.yaml"
+        # Deliberately omit publications + sources from the slot list.
+        slots_file.write_text("edges: [id, subject, predicate, object, category]\n")
+        db_path = temp_dir / "out.duckdb"
+
+        config = JoinConfig(
+            node_files=[],
+            edge_files=[FileSpec(path=nested_edges_jsonl, format=KGXFormat.JSONL, file_type=KGXFileType.EDGES)],
+            database_path=db_path,
+            slots_file=slots_file,
+            quiet=True,
+            show_progress=False,
+        )
+        join_graphs(config)
+        with duckdb.connect(str(db_path)) as conn:
+            cols = {row[0] for row in conn.execute("DESCRIBE edges").fetchall()}
+            assert "publications" not in cols
+            assert "sources" not in cols
+            assert {"id", "subject", "predicate", "object", "category"}.issubset(cols)
+
+    def test_slots_file_skips_files_without_file_type(self, temp_dir):
+        """A FileSpec with file_type=None (ambiguous filename) is left
+        untouched by _apply_slots_file — we don't guess whether it's nodes
+        or edges based on the slots that happen to match."""
+        from koza.graph_operations.join import _apply_slots_file
+
+        # Filename without _nodes or _edges → FileSpec's file_type validator
+        # leaves file_type=None.
+        ambiguous = temp_dir / "data.jsonl"
+        ambiguous.write_text('{"id": "x"}\n')
+
+        slots_file = temp_dir / "slots.yaml"
+        slots_file.write_text(
+            "nodes: [id, category, name]\n"
+            "edges: [id, subject, predicate, object]\n"
+        )
+        spec = FileSpec(path=ambiguous, format=KGXFormat.JSONL)
+        assert spec.file_type is None  # sanity: validator left it unset
+        config = JoinConfig(
+            node_files=[spec],
+            edge_files=[spec],
+            slots_file=slots_file,
+            quiet=True,
+        )
+        _apply_slots_file(config)
+        assert spec.slots is None
+
+
+class TestApplySlotsFile:
+    """Unit tests for _apply_slots_file's yaml-shape validation."""
+
+    @pytest.fixture
+    def _conf(self, temp_dir):
+        def make(yaml_text: str) -> JoinConfig:
+            f = temp_dir / "slots.yaml"
+            f.write_text(yaml_text)
+            return JoinConfig(node_files=[], edge_files=[], slots_file=f, quiet=True)
+        return make
+
+    def test_apply_no_slots_file_is_noop(self):
+        from koza.graph_operations.join import _apply_slots_file
+
+        _apply_slots_file(JoinConfig(node_files=[], edge_files=[], quiet=True))  # no raise
+
+    def test_apply_accepts_well_formed_yaml(self, _conf):
+        from koza.graph_operations.join import _apply_slots_file
+
+        _apply_slots_file(_conf("nodes: [id, category]\nedges: [id, subject, predicate, object]\n"))
+
+    def test_apply_accepts_partial_yaml(self, _conf):
+        from koza.graph_operations.join import _apply_slots_file
+
+        _apply_slots_file(_conf("nodes: [id, category]\n"))  # edges key omitted
+        _apply_slots_file(_conf("edges: [id, subject, predicate, object]\n"))  # nodes omitted
+
+    def test_apply_rejects_non_mapping_root(self, _conf):
+        from koza.graph_operations.join import _apply_slots_file
+
+        with pytest.raises(ValueError, match="must be a mapping"):
+            _apply_slots_file(_conf("- id\n- category\n"))
+
+    def test_apply_rejects_scalar_node_value(self, _conf):
+        from koza.graph_operations.join import _apply_slots_file
+
+        with pytest.raises(ValueError, match="'nodes' must be a list of strings"):
+            _apply_slots_file(_conf("nodes: id\n"))
+
+    def test_apply_rejects_non_string_items(self, _conf):
+        from koza.graph_operations.join import _apply_slots_file
+
+        with pytest.raises(ValueError, match="'edges' must be a list of strings"):
+            _apply_slots_file(_conf("edges: [id, 42, predicate]\n"))
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -1050,5 +1050,90 @@ HGNC:123\tbiolink:related_to\tMONDO:001
             join_graphs(config)
 
 
+class TestSlotsFile:
+    """End-to-end join with --slots-file driving the explicit-schema JSONL path."""
+
+    @pytest.fixture
+    def nested_nodes_jsonl(self, temp_dir):
+        """Nodes file with canonical Biolink shape: `category` is a list."""
+        content = (
+            '{"id": "CHEBI:1", "category": ["biolink:ChemicalEntity"], "name": "c1"}\n'
+            '{"id": "CHEBI:2", "category": ["biolink:ChemicalEntity"], "name": "c2"}\n'
+        )
+        path = temp_dir / "nested_nodes.jsonl"
+        path.write_text(content)
+        return path
+
+    @pytest.fixture
+    def nested_edges_jsonl(self, temp_dir):
+        """Edges file with translator-shape nested fields: list-of-string
+        `category`, list of `sources` structs, list of CURIE-ref `publications`.
+        Inference would need to scan; the explicit schema reads in one shot."""
+        content = (
+            '{"id": "u1", "subject": "HGNC:1", "predicate": "biolink:related_to", '
+            '"object": "HGNC:2", "category": ["biolink:Association"], '
+            '"publications": ["PMID:1"], '
+            '"sources": [{"resource_id": "infores:test", "resource_role": "primary_knowledge_source"}]}\n'
+            '{"id": "u2", "subject": "HGNC:3", "predicate": "biolink:related_to", '
+            '"object": "HGNC:4", "category": ["biolink:Association"], '
+            '"publications": ["PMID:2", "PMID:3"], '
+            '"sources": [{"resource_id": "infores:test", "resource_role": "primary_knowledge_source"}]}\n'
+        )
+        path = temp_dir / "nested_edges.jsonl"
+        path.write_text(content)
+        return path
+
+    def test_slots_file_loads_jsonl_with_explicit_schema(self, nested_nodes_jsonl, nested_edges_jsonl, temp_dir):
+        import duckdb
+
+        slots_file = temp_dir / "slots.yaml"
+        slots_file.write_text(
+            "nodes: [id, category, name]\n"
+            "edges: [id, subject, predicate, object, category, publications, sources]\n"
+        )
+        db_path = temp_dir / "out.duckdb"
+
+        config = JoinConfig(
+            node_files=[FileSpec(path=nested_nodes_jsonl, format=KGXFormat.JSONL, file_type=KGXFileType.NODES)],
+            edge_files=[FileSpec(path=nested_edges_jsonl, format=KGXFormat.JSONL, file_type=KGXFileType.EDGES)],
+            database_path=db_path,
+            slots_file=slots_file,
+            quiet=True,
+            show_progress=False,
+        )
+        result = join_graphs(config)
+        assert result.final_stats.nodes == 2
+        assert result.final_stats.edges == 2
+
+        # Verify the explicit schema took effect end-to-end: multivalued
+        # primitives become <scalar>[], inlined_as_list classes become
+        # STRUCT(...)[].
+        with duckdb.connect(str(db_path)) as conn:
+            edges_schema = {row[0]: row[1] for row in conn.execute("DESCRIBE edges").fetchall()}
+            nodes_schema = {row[0]: row[1] for row in conn.execute("DESCRIBE nodes").fetchall()}
+            assert edges_schema["category"] == "VARCHAR[]"
+            assert edges_schema["publications"] == "VARCHAR[]"
+            assert edges_schema["sources"].startswith("STRUCT(") and edges_schema["sources"].endswith(")[]")
+            assert nodes_schema["category"] == "VARCHAR[]"
+
+    def test_slots_file_rejects_unknown_slot(self, nested_nodes_jsonl, temp_dir):
+        from koza.graph_operations.graph_schema import UnknownSlotsError
+
+        slots_file = temp_dir / "slots.yaml"
+        slots_file.write_text("nodes: [id, category, name, not_a_biolink_slot]\n")
+        db_path = temp_dir / "out.duckdb"
+
+        config = JoinConfig(
+            node_files=[FileSpec(path=nested_nodes_jsonl, format=KGXFormat.JSONL, file_type=KGXFileType.NODES)],
+            edge_files=[],
+            database_path=db_path,
+            slots_file=slots_file,
+            quiet=True,
+            show_progress=False,
+        )
+        with pytest.raises(UnknownSlotsError, match="not_a_biolink_slot"):
+            join_graphs(config)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Summary

Adds support for an explicit JSONL schema, supplied by the user as a slot list, that bypasses DuckDB's schema inference entirely. Aimed at large KGX JSONL files (translator-kg, robokop) where inference is either too slow (sample-cliff retries with `sample_size=-1`) or silently lossy (e.g. nested `sources` flattened, scalar/list type collisions).

The slot list goes in via a yaml file:

```yaml
# slots.yaml
nodes: [id, category, name, description, ...]
edges: [id, subject, predicate, object, category, publications, sources, has_supporting_studies, ...]
```

Used as:

```
koza join -n nodes.jsonl -e edges.jsonl --slots-file slots.yaml -o out.duckdb
```

The slot list is the user's input; the *types* come from Biolink via the canonical `graph_schema.load_biolink_schemaview()`. Type dispatch follows LinkML semantics — see commit 1 for the table.

## Two commits

**1. `Add duckdb_columns_for_slots`** — pure helper in `graph_schema.py`:

| LinkML flags | DuckDB type |
|---|---|
| primitive range, scalar | `<scalar>` (VARCHAR / DOUBLE / BIGINT / BOOLEAN) |
| primitive range, multivalued | `<scalar>[]` |
| class range, scalar | `VARCHAR` (CURIE ref) |
| class range, mv + `inlined_as_list` | `STRUCT(...)[]` (recurse depth 2 → JSON) |
| class range, mv + `inlined` | `MAP(VARCHAR, STRUCT(...))` |
| class range, mv + neither flag | `VARCHAR[]` (CURIE refs) |

Reuses `_biolink_slot_pool`, `KOZA_INGEST_EXTRAS`, and `UnknownSlotsError` so strict-reject (ADR-0001) applies uniformly with the existing header-based seam.

**2. `Wire slots_file through JoinConfig -> FileSpec -> read_json columns`** — the consumer side:

- `JoinConfig.slots_file: Path | None` + `FileSpec.slots: list[str] | None`
- `get_duckdb_read_statement` emits `read_json(..., columns={...})` when slots are set
- Skips post-load `_transform_multivalued_columns` when slots are explicit (otherwise FORCE_SINGLE_VALUED flattens Biolink-declared `VARCHAR[]` back to `VARCHAR`)
- Lets `UnknownSlotsError` propagate out of `load_file`

## Translator-kg validation

End-to-end on the full translator-kg release (1.7M nodes / 29.4M edges from ~28 GB JSONL):

| Metric | Value |
|---|---|
| Wall | 105 s (read_json 38.5s + `create_final_tables` ~57s + cleanup ~10s) |
| Peak RSS | 8.0 GB |
| Output | 3.2 GB DuckDB with `_koza_schema` seeded (20 Entity slots, 59 Association slots) |

Schema landed as designed:

```
sources                  STRUCT(resource_id VARCHAR, resource_role VARCHAR, upstream_resource_ids VARCHAR[], ...)[]
has_supporting_studies   MAP(VARCHAR, STRUCT(has_study_results STRUCT(...), ...))
has_affinity             STRUCT(affinity_parameter VARCHAR, affinity DOUBLE, ...)[]
category                 VARCHAR[]
publications             VARCHAR[]
p_value                  DOUBLE
evidence_count           BIGINT
negated                  BOOLEAN
```

## Interim CLI surface

`koza join --slots-file` is the v1 surface. `join` is awkward for the single-file case (no merge semantics), so the next PR will likely add:

- `koza convert` — JSONL ↔ Parquet transcode through an in-memory DuckDB, no `_koza_schema`, aimed at the "magic this big JSONL into parquet for analytics" use case
- `koza load` — single-source → koza-shape DuckDB with seeded schema
- `koza join` reserved for actual multi-file joins

The plumbing here is verb-agnostic and carries over.

## Test plan

- [x] 11 new unit tests for `duckdb_columns_for_slots` covering all LinkML-flag dispatch branches
- [x] 2 new integration tests for `join --slots-file`: end-to-end correctness on translator-shape nested fields, strict-reject on unknown slot
- [x] Full test suite passes: 81 / 81 in join + utils + graph_schema
- [x] Real translator-kg load (~28 GB JSONL) runs end-to-end in 105 s

## Open follow-ups (not in this PR)

- `koza convert` / `koza load` CLI verbs as above
- Robokop validation (TRAPI-shape metadata adapter for generating `slots.yaml`)
- `koza schema rebase` integration when stored Biolink and current Biolink diverge