### PR TITLE
Add Biolink slot references to exported graph schema

### DIFF
--- a/src/koza/graph_operations/graph_schema.py
+++ b/src/koza/graph_operations/graph_schema.py
@@ -12,6 +12,7 @@ import importlib
 import importlib.resources as ir
 
 import duckdb
+import yaml
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model.meta import (
     ClassDefinition,
@@ -20,6 +21,7 @@ from linkml_runtime.linkml_model.meta import (
     SlotDefinition,
 )
 from linkml_runtime.loaders import yaml_loader
+from linkml_runtime.utils.schema_as_dict import schema_as_dict
 from linkml_runtime.utils.schemaview import SchemaView
 
 
@@ -92,6 +94,38 @@ def _snake_case(biolink_name: str) -> str:
     return biolink_name.replace(" ", "_")
 
 
+# CURIE prefixes that can appear in exported slot_uri / exact_mappings, with
+# their canonical reference URIs. Kept static so export stays standalone and
+# does not re-load Biolink (ADR-0002): slot_uri across the Biolink slot pool
+# resolves to one of these, and exact_mappings always use `biolink`.
+_KNOWN_PREFIX_URIS: dict[str, str] = {
+    "linkml": "https://w3id.org/linkml/",
+    "biolink": "https://w3id.org/biolink/vocab/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "dct": "http://purl.org/dc/terms/",
+    "schema": "http://schema.org/",
+}
+
+
+def _biolink_derived_slot(sv: SchemaView, col: str) -> SlotDefinition:
+    """A SlotDefinition for a column that matched the Biolink slot pool,
+    carrying semantic references back to the Biolink slot it was derived from.
+
+    `slot_uri` is Biolink's canonical predicate URI for the slot — usually
+    `biolink:<name>`, but for some slots Biolink maps it elsewhere (e.g. `name`
+    → `rdfs:label`, `subject` → `rdf:subject`). `exact_mappings` pins the
+    Biolink slot identity (`biolink:<name>`) regardless, so provenance to the
+    originating Biolink slot survives even when slot_uri points away.
+    """
+    try:
+        biolink_slot = sv.get_slot(col.replace("_", " "))
+        slot_uri = sv.get_uri(biolink_slot) if biolink_slot is not None else None
+    except Exception:
+        slot_uri = None
+    return SlotDefinition(name=col, slot_uri=slot_uri, exact_mappings=[f"biolink:{col}"])
+
+
 def _biolink_slot_pool(sv: SchemaView, root_class: str) -> set[str]:
     """All slots defined on the root class or any descendant, snake_cased.
 
@@ -123,7 +157,7 @@ def _flatten(
     rejected: list[str] = []
     for col in headers:
         if col in pool:
-            slots[col] = SlotDefinition(name=col)
+            slots[col] = _biolink_derived_slot(sv, col)
         elif col in declared_outputs:
             slots[col] = SlotDefinition(name=col, **declared_outputs[col])
         elif col in KOZA_INGEST_EXTRAS:
@@ -301,12 +335,21 @@ def export_schema(
         schema.imports = list(schema.imports or []) + ["linkml:types"]
     if not schema.default_range:
         schema.default_range = "string"
+    # Declare every prefix the schema actually references — linkml:types plus
+    # the prefixes used by the slot_uri / exact_mappings we attach to derived
+    # slots — so the released schema is standalone-loadable for CURIE expansion.
     prefixes = dict(schema.prefixes or {})
-    for prefix, uri in (
-        ("linkml", "https://w3id.org/linkml/"),
-        ("biolink", "https://w3id.org/biolink/vocab/"),
-    ):
-        prefixes.setdefault(prefix, Prefix(prefix_prefix=prefix, prefix_reference=uri))
+    used_prefixes = {"linkml", "biolink"}
+    for slot in schema.slots.values():
+        for curie in [slot.slot_uri, *(slot.exact_mappings or [])]:
+            if curie and ":" in curie:
+                used_prefixes.add(curie.split(":", 1)[0])
+    for prefix in used_prefixes:
+        uri = _KNOWN_PREFIX_URIS.get(prefix)
+        if uri:
+            prefixes.setdefault(
+                prefix, Prefix(prefix_prefix=prefix, prefix_reference=uri)
+            )
     schema.prefixes = prefixes
 
     if project_denormalized:
@@ -345,7 +388,10 @@ def export_schema(
             schema.slots[slot_name] = slot
         slot.multivalued = True
 
-    return yaml_dumper.dumps(schema)
+    # schema_as_dict emits the idiomatic compact schema form — `prefix: uri`
+    # rather than expanded Prefix objects, and drops redundant per-element
+    # `name:` keys — which is what LinkML tooling and humans expect.
+    return yaml.dump(schema_as_dict(schema), sort_keys=False)
 
 
 def is_seeded(conn: duckdb.DuckDBPyConnection) -> bool:

--- a/src/koza/graph_operations/graph_schema.py
+++ b/src/koza/graph_operations/graph_schema.py
@@ -23,6 +23,7 @@ from linkml_runtime.linkml_model.meta import (
 from linkml_runtime.loaders import yaml_loader
 from linkml_runtime.utils.schema_as_dict import schema_as_dict
 from linkml_runtime.utils.schemaview import SchemaView
+from loguru import logger
 
 
 ENTITY_ROOT = "named thing"
@@ -118,10 +119,11 @@ def _biolink_derived_slot(sv: SchemaView, col: str) -> SlotDefinition:
     Biolink slot identity (`biolink:<name>`) regardless, so provenance to the
     originating Biolink slot survives even when slot_uri points away.
     """
+    biolink_slot = sv.get_slot(col.replace("_", " "))
     try:
-        biolink_slot = sv.get_slot(col.replace("_", " "))
         slot_uri = sv.get_uri(biolink_slot) if biolink_slot is not None else None
     except Exception:
+        logger.warning(f"Could not resolve slot_uri for Biolink slot {col!r}")
         slot_uri = None
     return SlotDefinition(name=col, slot_uri=slot_uri, exact_mappings=[f"biolink:{col}"])
 
@@ -346,10 +348,15 @@ def export_schema(
                 used_prefixes.add(curie.split(":", 1)[0])
     for prefix in used_prefixes:
         uri = _KNOWN_PREFIX_URIS.get(prefix)
-        if uri:
-            prefixes.setdefault(
-                prefix, Prefix(prefix_prefix=prefix, prefix_reference=uri)
+        if uri is None:
+            raise ValueError(
+                f"Slot references use CURIE prefix {prefix!r} which has no entry "
+                f"in _KNOWN_PREFIX_URIS — the exported schema would not be "
+                f"standalone-loadable. Add its reference URI to _KNOWN_PREFIX_URIS."
             )
+        prefixes.setdefault(
+            prefix, Prefix(prefix_prefix=prefix, prefix_reference=uri)
+        )
     schema.prefixes = prefixes
 
     if project_denormalized:
@@ -391,7 +398,7 @@ def export_schema(
     # schema_as_dict emits the idiomatic compact schema form — `prefix: uri`
     # rather than expanded Prefix objects, and drops redundant per-element
     # `name:` keys — which is what LinkML tooling and humans expect.
-    return yaml.dump(schema_as_dict(schema), sort_keys=False)
+    return yaml.dump(schema_as_dict(schema), sort_keys=False, allow_unicode=True)
 
 
 def is_seeded(conn: duckdb.DuckDBPyConnection) -> bool:

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -22,6 +22,7 @@ from koza.graph_operations.graph_schema import (
     discover_declared_outputs,
     duckdb_columns_for_slots,
     ensure_slots,
+    export_schema,
     seed_schema,
     stored_biolink_yaml,
 )
@@ -44,6 +45,54 @@ def test_derive_schema_flattens_entity_class_from_node_headers(biolink_schemavie
 
     entity_slots = set(schema.classes["Entity"].slots)
     assert {"id", "category", "name"}.issubset(entity_slots)
+
+
+def test_derived_slots_reference_their_biolink_origin(biolink_schemaview):
+    """Each slot flattened from Biolink carries a semantic reference back to
+    the Biolink slot it came from: slot_uri (Biolink's canonical predicate URI)
+    plus an exact_mapping pinning the Biolink slot identity."""
+    schema = derive_schema(
+        nodes_headers=["id", "category", "name"],
+        edges_headers=["subject", "predicate", "object"],
+        biolink_schemaview=biolink_schemaview,
+    )
+
+    # slot_uri reflects Biolink's own mapping — biolink: for most, rdfs:/rdf:
+    # for the slots Biolink maps elsewhere.
+    assert schema.slots["category"].slot_uri == "biolink:category"
+    assert schema.slots["name"].slot_uri == "rdfs:label"
+    assert schema.slots["subject"].slot_uri == "rdf:subject"
+
+    # exact_mappings always pin the originating Biolink slot identity.
+    assert schema.slots["category"].exact_mappings == ["biolink:category"]
+    assert schema.slots["name"].exact_mappings == ["biolink:name"]
+    assert schema.slots["subject"].exact_mappings == ["biolink:subject"]
+
+    # Koza extras are not Biolink-derived and carry no Biolink reference.
+    assert not schema.slots["file_source"].exact_mappings
+
+
+def test_export_declares_prefixes_for_slot_references(biolink_schemaview, tmp_path):
+    """The exported schema must declare every prefix its slot references use so
+    it stays standalone-loadable for CURIE expansion."""
+    db_path = tmp_path / "test.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        seed_schema(
+            conn,
+            nodes_headers=["id", "category", "name"],
+            edges_headers=["subject", "predicate", "object"],
+            biolink_schemaview=biolink_schemaview,
+        )
+        exported = export_schema(conn, project_denormalized=False)
+    finally:
+        conn.close()
+
+    assert "biolink: https://w3id.org/biolink/vocab/" in exported
+    assert "rdfs: http://www.w3.org/2000/01/rdf-schema#" in exported
+    assert "rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#" in exported
+    assert "slot_uri: rdfs:label" in exported
+    assert "biolink:name" in exported
 
 
 def test_file_source_is_injected_as_koza_extra(biolink_schemaview):

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -94,6 +94,12 @@ def test_export_declares_prefixes_for_slot_references(biolink_schemaview, tmp_pa
     assert "slot_uri: rdfs:label" in exported
     assert "biolink:name" in exported
 
+    # The actual contract: the exported schema loads standalone and its
+    # CURIEs resolve — not just that the text appears.
+    reloaded = SchemaView(exported)
+    assert reloaded.expand_curie("rdfs:label") == "http://www.w3.org/2000/01/rdf-schema#label"
+    assert reloaded.expand_curie("biolink:name") == "https://w3id.org/biolink/vocab/name"
+
 
 def test_file_source_is_injected_as_koza_extra(biolink_schemaview):
     """file_source is injected unconditionally by load_file; the schema must


### PR DESCRIPTION
## What

Slots in the exported graph schema were emitted as bare `SlotDefinition(name=col)` with no semantic link back to the Biolink slot they were derived from. This adds that reference.

Each Biolink-derived slot now carries:

- **`slot_uri`** — Biolink's canonical predicate URI. `biolink:<name>` for most slots, but `rdfs:`/`rdf:` for the slots Biolink deliberately maps elsewhere (`name` → `rdfs:label`, `subject` → `rdf:subject`, etc.).
- **`exact_mappings: [biolink:<name>]`** — pins the originating Biolink slot identity regardless of where `slot_uri` points, so provenance back to the Biolink slot survives even for the rdfs/rdf-mapped slots.

Example:

```yaml
slots:
  category:
    slot_uri: biolink:category
    exact_mappings:
      - biolink:category
  name:
    slot_uri: rdfs:label
    exact_mappings:
      - biolink:name
```

## How

- `_biolink_derived_slot(sv, col)` builds the slot with both references; `_flatten` routes pool-matched columns through it. Koza extras and declared outputs are untouched (not Biolink-derived).
- `export_schema` declares every prefix its slot references actually use (`biolink`, `rdf`, `rdfs`, `dct`, `schema`, `linkml`) from a static map — no Biolink re-load, per ADR-0002 — so the released schema stays standalone-loadable.
- Export now serializes via `schema_as_dict`, giving the idiomatic compact `prefix: uri` form (and dropping redundant per-element `name:` keys).

## Notes

References are attached at derive/seed time and persisted in the DuckDB-stored schema, so **rebuilding the merged graph** is required to pick them up — databases seeded before this change won't have them.

## Tests

Added `test_derived_slots_reference_their_biolink_origin` and `test_export_declares_prefixes_for_slot_references`. Verified the exported schema loads standalone with CURIEs resolving. Full `test_graph_schema.py` passes (26 tests).