### PR TITLE
Emit LinkML `range` in exported schema instead of defaulting to string

### DIFF
--- a/src/koza/graph_operations/graph_schema.py
+++ b/src/koza/graph_operations/graph_schema.py
@@ -95,6 +95,64 @@ def _snake_case(biolink_name: str) -> str:
     return biolink_name.replace(" ", "_")
 
 
+# LinkML built-in scalar types that downstream LinkML tooling resolves without
+# a Biolink import. The released schema only imports `linkml:types`, so every
+# slot range it emits must reduce to one of these to stay standalone-loadable
+# (ADR-0002). `uriorcurie`/`uri` are kept (they carry identifier intent and
+# tools collapse them to a string field); anything else falls back to `string`.
+_LINKML_BUILTIN_PRIMITIVES: frozenset[str] = frozenset(
+    {
+        "string",
+        "integer",
+        "boolean",
+        "float",
+        "double",
+        "decimal",
+        "date",
+        "datetime",
+        "time",
+        "uriorcurie",
+        "uri",
+    }
+)
+
+
+def _primitive_range(sv: SchemaView, range_name: str | None) -> str | None:
+    """Reduce a Biolink range to a standalone-resolvable LinkML primitive.
+
+    The released schema (see `export_schema`) imports only `linkml:types`, so a
+    range that names a Biolink class, enum, or type would be a dangling
+    reference — linkml-solr's `create-schema` and other LinkML tooling reject
+    it. We resolve here, at derive time, where the Biolink SchemaView is in hand
+    (ADR-0002 keeps export from re-loading Biolink):
+
+    - class-valued slot  → ``uriorcurie`` (the column holds a CURIE reference)
+    - enum-valued slot   → ``string`` (permissible values serialize as strings)
+    - type-valued slot   → walk the ``typeof`` chain to the underlying built-in
+
+    The resolved primitive is informational only — no operation dispatches on
+    the stored range (column types come from the live Biolink SchemaView via
+    `duckdb_columns_for_slots`), and Biolink slot identity is preserved on every
+    slot through `slot_uri` / `exact_mappings`.
+    """
+    if range_name is None:
+        return None
+    if range_name in sv.all_classes():
+        return "uriorcurie"
+    if range_name in sv.all_enums():
+        return "string"
+    t = sv.get_type(range_name)
+    if t is None:
+        # Not a known class/enum/type — leave it for default_range handling.
+        return range_name
+    seen: set[str] = set()
+    while t is not None and t.typeof and t.name not in seen:
+        seen.add(t.name)
+        t = sv.get_type(t.typeof)
+    resolved = t.name if t is not None else range_name
+    return resolved if resolved in _LINKML_BUILTIN_PRIMITIVES else "string"
+
+
 # CURIE prefixes that can appear in exported slot_uri / exact_mappings, with
 # their canonical reference URIs. Kept static so export stays standalone and
 # does not re-load Biolink (ADR-0002): slot_uri across the Biolink slot pool
@@ -121,10 +179,16 @@ def _biolink_derived_slot(sv: SchemaView, col: str) -> SlotDefinition:
 
     `range` is captured from Biolink here (where the SchemaView is available)
     so it persists in the stored schema and the export doesn't have to reload
-    Biolink (ADR-0002) — e.g. `has_count` → integer, `negated` → boolean.
+    Biolink (ADR-0002) — e.g. `has_count` → integer, `negated` → boolean. It is
+    reduced to a standalone-resolvable LinkML primitive via `_primitive_range`
+    so the released schema (which imports only `linkml:types`) stays loadable —
+    e.g. `name` (Biolink `label type`) → string, `has_gene` (Biolink `gene`)
+    → uriorcurie.
     """
     biolink_slot = sv.get_slot(col.replace("_", " "))
-    slot_range = biolink_slot.range if biolink_slot is not None else None
+    slot_range = (
+        _primitive_range(sv, biolink_slot.range) if biolink_slot is not None else None
+    )
     try:
         slot_uri = sv.get_uri(biolink_slot) if biolink_slot is not None else None
     except Exception:

--- a/src/koza/graph_operations/graph_schema.py
+++ b/src/koza/graph_operations/graph_schema.py
@@ -118,14 +118,21 @@ def _biolink_derived_slot(sv: SchemaView, col: str) -> SlotDefinition:
     → `rdfs:label`, `subject` → `rdf:subject`). `exact_mappings` pins the
     Biolink slot identity (`biolink:<name>`) regardless, so provenance to the
     originating Biolink slot survives even when slot_uri points away.
+
+    `range` is captured from Biolink here (where the SchemaView is available)
+    so it persists in the stored schema and the export doesn't have to reload
+    Biolink (ADR-0002) — e.g. `has_count` → integer, `negated` → boolean.
     """
     biolink_slot = sv.get_slot(col.replace("_", " "))
+    slot_range = biolink_slot.range if biolink_slot is not None else None
     try:
         slot_uri = sv.get_uri(biolink_slot) if biolink_slot is not None else None
     except Exception:
         logger.warning(f"Could not resolve slot_uri for Biolink slot {col!r}")
         slot_uri = None
-    return SlotDefinition(name=col, slot_uri=slot_uri, exact_mappings=[f"biolink:{col}"])
+    return SlotDefinition(
+        name=col, range=slot_range, slot_uri=slot_uri, exact_mappings=[f"biolink:{col}"]
+    )
 
 
 def _biolink_slot_pool(sv: SchemaView, root_class: str) -> set[str]:
@@ -375,8 +382,10 @@ def export_schema(
                 new_classes[target] = cls_def
         schema.classes = new_classes
 
-    # Derive multivalued from actual DuckDB column types of the denormalized views.
+    # Derive multivalued + scalar range from actual DuckDB column types of the
+    # denormalized views.
     multivalued_slots: set[str] = set()
+    scalar_types: dict[str, str] = {}
     for table in ("denormalized_nodes", "denormalized_edges"):
         try:
             rows = conn.execute(f"DESCRIBE {table}").fetchall()
@@ -385,8 +394,11 @@ def export_schema(
             # with whatever Entity / Association slot info we have.
             continue
         for col_name, col_type, *_ in rows:
-            if "VARCHAR[]" in (col_type or "").upper():
+            upper = (col_type or "").upper()
+            if "VARCHAR[]" in upper:
                 multivalued_slots.add(col_name)
+            else:
+                scalar_types[col_name] = upper
 
     for slot_name in multivalued_slots:
         slot = schema.slots.get(slot_name)
@@ -394,6 +406,17 @@ def export_schema(
             slot = SlotDefinition(name=slot_name)
             schema.slots[slot_name] = slot
         slot.multivalued = True
+
+    # Recover range for computed, non-Biolink scalar columns from their DuckDB
+    # type — only where the slot has no range yet, so Biolink-derived ranges
+    # (captured at derive time) win over the lossy DuckDB inverse.
+    for slot_name, col_type in scalar_types.items():
+        slot = schema.slots.get(slot_name)
+        if slot is None or slot.range:
+            continue
+        rng = _DUCKDB_SCALAR_TO_RANGE.get(col_type)
+        if rng:
+            slot.range = rng
 
     # schema_as_dict emits the idiomatic compact schema form — `prefix: uri`
     # rather than expanded Prefix objects, and drops redundant per-element
@@ -441,6 +464,18 @@ _RANGE_TO_DUCKDB_SCALAR: dict[str, str] = {
     "float": "DOUBLE",
     "double": "DOUBLE",
     "boolean": "BOOLEAN",
+}
+
+# Inverse of the above for recovering a LinkML range from a computed, non-Biolink
+# DuckDB column (e.g. `has_phenotype_count` BIGINT). Lossy — DUCKDB DOUBLE can't
+# distinguish float from double — so this only fills slots Biolink didn't already
+# range at derive time, where the precise range is unknown anyway.
+_DUCKDB_SCALAR_TO_RANGE: dict[str, str] = {
+    "BIGINT": "integer",
+    "INTEGER": "integer",
+    "DOUBLE": "float",
+    "FLOAT": "float",
+    "BOOLEAN": "boolean",
 }
 
 # Biolink ranges treated as "primitive" for the purpose of multivalued

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -88,6 +88,40 @@ def test_derived_slots_carry_their_biolink_range(biolink_schemaview):
     assert schema.slots["category"].range == "uriorcurie"
 
 
+def test_derived_ranges_reduce_to_standalone_primitives(biolink_schemaview):
+    """Class-, enum-, and type-valued Biolink ranges are reduced to LinkML
+    primitives so the released schema (which imports only `linkml:types`) has no
+    dangling range references — the contract linkml-solr's create-schema needs.
+    """
+    schema = derive_schema(
+        nodes_headers=["id", "name", "in_taxon", "has_attribute"],
+        edges_headers=["subject", "predicate", "object", "knowledge_level"],
+        biolink_schemaview=biolink_schemaview,
+    )
+
+    # Biolink type whose typeof chain bottoms out at string (`label type`).
+    assert schema.slots["name"].range == "string"
+    # Biolink class-valued slots hold CURIE references → uriorcurie.
+    assert schema.slots["in_taxon"].range == "uriorcurie"
+    assert schema.slots["subject"].range == "uriorcurie"
+    assert schema.slots["object"].range == "uriorcurie"
+    # Biolink enum-valued slot serializes permissible values as strings.
+    assert schema.slots["knowledge_level"].range == "string"
+
+    # Every emitted range resolves against linkml:types alone — no Biolink
+    # class/enum/type names leak into the standalone schema.
+    standalone = {
+        "string", "integer", "boolean", "float", "double", "decimal",
+        "date", "datetime", "time", "uriorcurie", "uri",
+    }
+    from jsonasobj2 import items
+
+    for name, slot in items(schema.slots):
+        assert slot.range is None or slot.range in standalone, (
+            f"slot {name!r} has non-primitive range {slot.range!r}"
+        )
+
+
 def test_export_declares_prefixes_for_slot_references(biolink_schemaview, tmp_path):
     """The exported schema must declare every prefix its slot references use so
     it stays standalone-loadable for CURIE expansion."""

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -72,6 +72,22 @@ def test_derived_slots_reference_their_biolink_origin(biolink_schemaview):
     assert not schema.slots["file_source"].exact_mappings
 
 
+def test_derived_slots_carry_their_biolink_range(biolink_schemaview):
+    """Biolink-typed slots carry Biolink's range, captured at derive time so it
+    persists in the stored schema rather than defaulting to string at export."""
+    schema = derive_schema(
+        nodes_headers=["id", "category", "name"],
+        edges_headers=["subject", "predicate", "object", "negated", "has_count", "has_percentage"],
+        biolink_schemaview=biolink_schemaview,
+    )
+
+    assert schema.slots["has_count"].range == "integer"
+    assert schema.slots["has_percentage"].range == "double"
+    assert schema.slots["negated"].range == "boolean"
+    # Full scope: string-ish ranges are emitted explicitly too, not left to default.
+    assert schema.slots["category"].range == "uriorcurie"
+
+
 def test_export_declares_prefixes_for_slot_references(biolink_schemaview, tmp_path):
     """The exported schema must declare every prefix its slot references use so
     it stays standalone-loadable for CURIE expansion."""
@@ -99,6 +115,32 @@ def test_export_declares_prefixes_for_slot_references(biolink_schemaview, tmp_pa
     reloaded = SchemaView(exported)
     assert reloaded.expand_curie("rdfs:label") == "http://www.w3.org/2000/01/rdf-schema#label"
     assert reloaded.expand_curie("biolink:name") == "https://w3id.org/biolink/vocab/name"
+
+
+def test_export_recovers_range_for_computed_scalar_columns(biolink_schemaview, tmp_path):
+    """Computed, non-Biolink scalar columns (e.g. has_phenotype_count) get their
+    range from the DuckDB column type, so they don't fall back to string."""
+    db_path = tmp_path / "test.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        seed_schema(
+            conn,
+            nodes_headers=["id", "category", "name"],
+            edges_headers=["subject", "predicate", "object", "has_phenotype_count"],
+            biolink_schemaview=biolink_schemaview,
+        )
+        # has_phenotype_count isn't a Biolink slot — its only type signal is the
+        # DuckDB column. (The denormalized views are what export introspects.)
+        conn.execute(
+            "CREATE TABLE denormalized_edges "
+            "(subject VARCHAR, predicate VARCHAR, object VARCHAR, has_phenotype_count BIGINT)"
+        )
+        exported = export_schema(conn, project_denormalized=False)
+    finally:
+        conn.close()
+
+    reloaded = SchemaView(exported)
+    assert reloaded.get_slot("has_phenotype_count").range == "integer"
 
 
 def test_file_source_is_injected_as_koza_extra(biolink_schemaview):


### PR DESCRIPTION
Closes #215.

## What

`export_schema()` set `multivalued` from DuckDB column types but never set a slot's `range`, so every slot serialized as `slot_name: {}` and fell back to `default_range: string` — even when the type was unambiguously known (`has_count` → integer, `negated` → boolean, `has_percentage` → double). Downstream consumers (monarch-app) had to hand-override ~8 ranges, reintroducing the drift the generated schema exists to prevent.

## How

Two type sources koza already has, set in two places:

- **Biolink-typed slots** — `range` is captured at *derive* time in `_biolink_derived_slot`, where the `SchemaView` is in hand. It persists in the stored schema (same as `slot_uri`/`exact_mappings`) so export needs no Biolink reload (ADR-0002).
- **Computed, non-Biolink scalars** (e.g. `has_phenotype_count` `BIGINT`) — the export DESCRIBE loop reverse-maps the DuckDB scalar type via `_DUCKDB_SCALAR_TO_RANGE`, but **only where Biolink didn't already set a range**, so the precise Biolink range wins over the lossy DuckDB inverse (DOUBLE can't distinguish float from double).

Full scope: string-ish Biolink ranges (`uriorcurie`, `label type`, `named thing`) are now emitted explicitly too, not left to `default_range`.

## Result

| field | source | emitted range |
|---|---|---|
| `has_count`, `has_total`, `evidence_count` | Biolink | `integer` |
| `has_percentage`, `has_quotient` | Biolink | `double` |
| `negated` | Biolink | `boolean` |
| `has_phenotype_count`, `has_descendant_count` | DuckDB `BIGINT` | `integer` |

## Notes

Range is baked into the stored schema at seed time, so **rebuilding the merged graph** is required to pick it up — databases seeded before this change won't have it.

## Tests

Added `test_derived_slots_carry_their_biolink_range` and `test_export_recovers_range_for_computed_scalar_columns`. Full suite passes (405 tests).