### PR TITLE
Update external GitHub workflows

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
       - name: Set up Python 3
-        uses: actions/setup-python@main
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           version: ${{ env.UV_VERSION }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           version: ${{ env.UV_VERSION }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           version: ${{ env.UV_VERSION }}


### PR DESCRIPTION
Updates from `gh-external-audit update`:

- actions/checkout: main → v6 (major tag) — was tracking `main` branch; switched to versioned pin
- actions/checkout: v4 → v6 (major tag)
- actions/setup-python: main → v6 (major tag) — was tracking `main` branch; switched to versioned pin
- astral-sh/setup-uv: v7 → v8.1.0 (exact tag) — setup-uv stopped publishing moving major tags from v8 onward (immutable releases policy); exact pin required
