### PR TITLE
Make closure_file optional for closurize

### DIFF
--- a/src/koza/graph_operations/_closurize_engine.py
+++ b/src/koza/graph_operations/_closurize_engine.py
@@ -107,6 +107,7 @@ def build_node_predicate_side_table(
     db,
     predicate: str,
     additional_filter: Optional[str] = None,
+    include_closure: bool = True,
 ) -> str:
     """Build a per-predicate node-extension side table aggregating object info
     for edges where nodes.id is the subject and the edge has the given predicate.
@@ -116,11 +117,27 @@ def build_node_predicate_side_table(
     by one predicate's edge subset.
 
     Returns the side table name; columns are (id, <field>, <field>_label,
-    <field>_count, <field>_closure, <field>_closure_label).
+    <field>_count) plus (<field>_closure, <field>_closure_label) when
+    `include_closure` is set. With no closure file, the closure columns are
+    omitted entirely (the closure_id / closure_label side tables don't exist).
     """
     field = predicate.replace("biolink:", "")
     side_table = f"node_{field}"
     extra = f"AND ({additional_filter})" if additional_filter else ""
+    if include_closure:
+        closure_columns = f""",
+      CASE WHEN COUNT(c.closure) > 0
+           THEN LIST_DISTINCT(FLATTEN(ARRAY_AGG(c.closure)))
+           ELSE NULL END AS {field}_closure,
+      CASE WHEN COUNT(cl.closure_label) > 0
+           THEN LIST_DISTINCT(FLATTEN(ARRAY_AGG(cl.closure_label)))
+           ELSE NULL END AS {field}_closure_label"""
+        closure_joins = """
+    LEFT JOIN closure_id c ON e.object = c.id
+    LEFT JOIN closure_label cl ON e.object = cl.id"""
+    else:
+        closure_columns = ""
+        closure_joins = ""
     db.sql(f"""
     CREATE OR REPLACE TABLE {side_table} AS
     SELECT
@@ -131,21 +148,13 @@ def build_node_predicate_side_table(
       CASE WHEN COUNT(DISTINCT o.name) > 0
            THEN ARRAY_AGG(DISTINCT o.name)
            ELSE NULL END AS {field}_label,
-      COUNT(DISTINCT e.object) AS {field}_count,
-      CASE WHEN COUNT(c.closure) > 0
-           THEN LIST_DISTINCT(FLATTEN(ARRAY_AGG(c.closure)))
-           ELSE NULL END AS {field}_closure,
-      CASE WHEN COUNT(cl.closure_label) > 0
-           THEN LIST_DISTINCT(FLATTEN(ARRAY_AGG(cl.closure_label)))
-           ELSE NULL END AS {field}_closure_label
+      COUNT(DISTINCT e.object) AS {field}_count{closure_columns}
     FROM nodes n
     LEFT JOIN edges e
       ON n.id = e.subject
      AND e.predicate = 'biolink:{field}'
      {extra}
-    LEFT JOIN nodes o ON e.object = o.id
-    LEFT JOIN closure_id c ON e.object = c.id
-    LEFT JOIN closure_label cl ON e.object = cl.id
+    LEFT JOIN nodes o ON e.object = o.id{closure_joins}
     GROUP BY n.id
     """)
     return side_table
@@ -162,8 +171,8 @@ def materialize_column(db, table: str, column_name: str, expression: str, sql_ty
 
 
 
-def add_closure(closure_file: str,
-                database_path: str,
+def add_closure(database_path: str,
+                closure_file: Optional[str] = None,
                 node_fields: Optional[List[str]] = None,
                 edge_fields: Optional[List[str]] = None,
                 edge_fields_to_label: Optional[List[str]] = None,
@@ -174,13 +183,19 @@ def add_closure(closure_file: str,
     """Apply closure expansion to the nodes/edges tables in `database_path`.
 
     The DuckDB at `database_path` must already contain `nodes` and `edges`
-    tables (produced upstream by `koza join`). `closure_file` is a TSV with
-    `(subject_id, predicate_id, object_id)` columns (e.g. the filtered
-    phenio relation graph).
+    tables (produced upstream by `koza join`). `closure_file`, when given, is
+    a TSV with `(subject_id, predicate_id, object_id)` columns (e.g. the
+    filtered phenio relation graph).
+
+    When `closure_file` is None, the denormalized views are still produced —
+    nodes/edges are joined for labels, categories, namespaces and per-predicate
+    aggregations — but no relation-graph closure is loaded, so the
+    `*_closure` / `*_closure_label` slots (and node-level `has_descendant*`)
+    are omitted entirely.
 
     Produces:
-    - Materialized closure side tables: `closure_id`, `closure_label`,
-      `descendants_id`, `descendants_label`.
+    - Materialized closure side tables `closure_id`, `closure_label`,
+      `descendants_id`, `descendants_label` (only when `closure_file` given).
     - New columns on `edges`: `evidence_count`, `grouping_key`.
     - One materialized side table per `node_fields` entry: `node_<predicate>`.
     - `denormalized_edges` VIEW and `denormalized_nodes` VIEW.
@@ -200,16 +215,18 @@ def add_closure(closure_file: str,
     if not os.path.exists(database_path):
         raise ValueError(f"database_path does not exist: {database_path}")
 
+    include_closure = closure_file is not None
     logger.info(f"Closurize: database={database_path}, closure_file={closure_file}")
     db = duckdb.connect(database=database_path)
     if mem := os.environ.get("DUCKDB_MEMORY_LIMIT"):
         db.sql(f"PRAGMA memory_limit='{mem}'")
 
     _ensure_namespace_column(db)
-    _build_closure_tables(db, closure_file)
+    if include_closure:
+        _build_closure_tables(db, closure_file)
     _materialize_edge_derived_columns(db, evidence_fields, grouping_fields)
-    _build_denormalized_edges_view(db, edge_fields, edge_fields_to_label)
-    _build_denormalized_nodes_view(db, node_fields, additional_node_constraints)
+    _build_denormalized_edges_view(db, edge_fields, edge_fields_to_label, include_closure)
+    _build_denormalized_nodes_view(db, node_fields, additional_node_constraints, include_closure)
 
 
 def _ensure_namespace_column(db: duckdb.DuckDBPyConnection) -> None:
@@ -290,13 +307,15 @@ def _build_denormalized_edges_view(
     db: duckdb.DuckDBPyConnection,
     edge_fields: List[str],
     edge_fields_to_label: List[str],
+    include_closure: bool = True,
 ) -> None:
-    """Create `denormalized_edges` VIEW: edges plus per-field closure expansions.
+    """Create `denormalized_edges` VIEW: edges plus per-field expansions.
 
     Each entry in `edge_fields` gets the full expansion (label, category,
-    namespace, closure, closure_label, plus taxon for subject/object).
-    Each entry in `edge_fields_to_label` gets the label-only expansion
-    (no closure joins).
+    namespace, plus taxon for subject/object). When `include_closure` is set,
+    closure / closure_label columns are added too; otherwise they're omitted
+    (no closure side tables exist). Each entry in `edge_fields_to_label` gets
+    the label-only expansion regardless.
     """
     edges_info = db.sql("DESCRIBE edges").fetchall()
     edges_types = {col[0]: col[1] for col in edges_info}
@@ -307,7 +326,7 @@ def _build_denormalized_edges_view(
         return "VARCHAR[]" in edges_types.get(field, "").upper()
 
     join_clauses = [
-        edge_joins(f, is_multivalued=is_multivalued(f))
+        edge_joins(f, include_closure_joins=include_closure, is_multivalued=is_multivalued(f))
         for f in edge_fields
     ] + [
         edge_joins(f, include_closure_joins=False, is_multivalued=is_multivalued(f))
@@ -324,7 +343,7 @@ def _build_denormalized_edges_view(
     edges_select = f"edges.* EXCLUDE ({', '.join(excluded)})" if excluded else "edges.*"
 
     projections = [
-        edge_columns(f, node_column_names=node_cols)
+        edge_columns(f, include_closure_fields=include_closure, node_column_names=node_cols)
         for f in edge_fields
     ] + [
         edge_columns(f, include_closure_fields=False, node_column_names=node_cols)
@@ -346,37 +365,51 @@ def _build_denormalized_nodes_view(
     db: duckdb.DuckDBPyConnection,
     node_fields: List[str],
     additional_node_constraints: Optional[str],
+    include_closure: bool = True,
 ) -> None:
     """Build per-predicate node side tables, then create `denormalized_nodes` VIEW.
 
     For each entry in `node_fields`, materialize a `node_<predicate>` side
-    table holding (id, <field>, <field>_label, <field>_count, <field>_closure,
-    <field>_closure_label). The view joins all of these to `nodes` plus
-    descendants_id / descendants_label.
+    table holding (id, <field>, <field>_label, <field>_count) plus
+    (<field>_closure, <field>_closure_label) when `include_closure` is set.
+    The view joins all of these to `nodes`, plus descendants_id /
+    descendants_label for the `has_descendant*` slots — also only when a
+    closure file was loaded.
     """
     side_joins: list[str] = []
     side_columns: list[str] = []
     for node_field in node_fields:
         field = node_field.replace("biolink:", "")
-        side_table = build_node_predicate_side_table(db, node_field, additional_node_constraints)
+        side_table = build_node_predicate_side_table(
+            db, node_field, additional_node_constraints, include_closure
+        )
         alias = f"_{field}"
         side_joins.append(f"LEFT JOIN {side_table} {alias} ON nodes.id = {alias}.id")
-        for col in (field, f"{field}_label", f"{field}_count",
-                    f"{field}_closure", f"{field}_closure_label"):
+        cols = [field, f"{field}_label", f"{field}_count"]
+        if include_closure:
+            cols += [f"{field}_closure", f"{field}_closure_label"]
+        for col in cols:
             side_columns.append(f"{alias}.{col}")
 
-    column_list = (", ".join(side_columns) + ",") if side_columns else ""
+    # Build the projection as an explicit list so the trailing comma is never
+    # in doubt whether or not closure (and its has_descendant* columns) is present.
+    projection = ["nodes.*", *side_columns]
+    descendant_joins = ""
+    if include_closure:
+        projection += [
+            "_d.descendants AS has_descendant",
+            "_dl.descendants_label AS has_descendant_label",
+            "COALESCE(ARRAY_LENGTH(_d.descendants), 0) AS has_descendant_count",
+        ]
+        descendant_joins = """
+        LEFT JOIN descendants_id _d ON nodes.id = _d.id
+        LEFT JOIN descendants_label _dl ON nodes.id = _dl.id"""
+
     _drop_any("denormalized_nodes", db)
     db.sql(f"""
         CREATE OR REPLACE VIEW denormalized_nodes AS
         SELECT
-            nodes.*,
-            {column_list}
-            _d.descendants AS has_descendant,
-            _dl.descendants_label AS has_descendant_label,
-            COALESCE(ARRAY_LENGTH(_d.descendants), 0) AS has_descendant_count
+            {", ".join(projection)}
         FROM nodes
-        {chr(10).join(side_joins)}
-        LEFT JOIN descendants_id _d ON nodes.id = _d.id
-        LEFT JOIN descendants_label _dl ON nodes.id = _dl.id
+        {chr(10).join(side_joins)}{descendant_joins}
     """)

--- a/src/koza/graph_operations/closurize.py
+++ b/src/koza/graph_operations/closurize.py
@@ -51,7 +51,7 @@ def closurize_graph(config: ClosurizeConfig) -> ClosurizeResult:
     try:
         add_closure(
             database_path=str(config.database_path),
-            closure_file=str(config.closure_file),
+            closure_file=str(config.closure_file) if config.closure_file is not None else None,
             edge_fields=list(config.edge_fields),
             edge_fields_to_label=list(config.edge_fields_to_label),
             node_fields=list(config.node_fields),

--- a/src/koza/main.py
+++ b/src/koza/main.py
@@ -519,10 +519,12 @@ def schema_export(  # noqa: PLR0913
 @typer_app.command()
 def closurize(
     database: Annotated[str, typer.Argument(help="Path to the DuckDB database file to closurize")],
-    closure_file: Annotated[str, typer.Option(
+    closure_file: Annotated[str | None, typer.Option(
         "--closure-file", "-c",
-        help="Path to the relation-graph TSV file (subject_id, predicate_id, object_id)"
-    )],
+        help="Path to the relation-graph TSV file (subject_id, predicate_id, object_id). "
+             "Omit to build denormalized views without closure: no *_closure / "
+             "*_closure_label slots and no node-level has_descendant* slots."
+    )] = None,
     node_fields: Annotated[list[str] | None, typer.Option(
         "--node-field", help="Predicate to expand into per-node aggregations (repeatable)"
     )] = None,
@@ -564,7 +566,7 @@ def closurize(
         # duplicated between the CLI and the model.
         config_kwargs = {
             "database_path": Path(database),
-            "closure_file": Path(closure_file),
+            "closure_file": Path(closure_file) if closure_file is not None else None,
             "additional_node_constraints": additional_node_constraints,
             "quiet": quiet,
         }

--- a/src/koza/model/graph_operations.py
+++ b/src/koza/model/graph_operations.py
@@ -551,7 +551,11 @@ class ClosurizeConfig(BaseModel):
     """
 
     database_path: Path
-    closure_file: Path
+    # closure_file is optional: when None, the denormalized views are still
+    # produced (labels, categories, namespaces, per-predicate aggregations)
+    # but no relation-graph closure is loaded, so the *_closure /
+    # *_closure_label slots and node-level has_descendant* are omitted.
+    closure_file: Path | None = None
     node_fields: list[str] = Field(default_factory=lambda: ["has_phenotype"])
     edge_fields: list[str] = Field(default_factory=lambda: ["subject", "object"])
     edge_fields_to_label: list[str] = Field(default_factory=list)
@@ -562,8 +566,8 @@ class ClosurizeConfig(BaseModel):
 
     @field_validator("database_path", "closure_file")
     @classmethod
-    def validate_path_exists(cls, v: Path) -> Path:
-        if not v.exists():
+    def validate_path_exists(cls, v: Path | None) -> Path | None:
+        if v is not None and not v.exists():
             raise ValueError(f"File not found: {v}")
         return v
 

--- a/tests/test_closurize.py
+++ b/tests/test_closurize.py
@@ -136,6 +136,58 @@ def test_closurize_evolves_stored_schema_to_four_classes(synthetic_kg, biolink_s
     assert {"subject_label", "subject_closure", "object_label", "object_closure"}.issubset(da_slots)
 
 
+def test_closurize_without_closure_file_omits_closure_slots(synthetic_kg, biolink_schemaview):
+    """With no closure_file, the denormalized views are still produced — labels,
+    categories, namespaces, per-predicate aggregations — but the *_closure /
+    *_closure_label slots and node-level has_descendant* slots are omitted."""
+    db_path, _ = synthetic_kg
+
+    with GraphDatabase(db_path) as db:
+        seed_schema(
+            db.conn,
+            nodes_headers=["id", "category", "name", "in_taxon", "in_taxon_label"],
+            edges_headers=["id", "subject", "predicate", "object", "category",
+                           "has_evidence", "publications", "negated", "namespace"],
+            biolink_schemaview=biolink_schemaview,
+        )
+
+    result = closurize_graph(
+        ClosurizeConfig(
+            database_path=db_path,
+            # closure_file omitted
+            node_fields=["has_phenotype"],
+            edge_fields=["subject", "object"],
+            quiet=True,
+        )
+    )
+
+    assert result.success
+    assert result.denormalized_edges_count == 2
+    assert result.denormalized_nodes_count == 4
+
+    with GraphDatabase(db_path) as db:
+        e_cols = {r[0] for r in db.conn.execute("DESCRIBE denormalized_edges").fetchall()}
+        # Label/category/namespace expansion still present...
+        assert {"subject_label", "subject_category", "subject_namespace",
+                "object_label"}.issubset(e_cols)
+        # ...but no closure slots.
+        assert not any(c.endswith("_closure") or c.endswith("_closure_label") for c in e_cols)
+
+        n_cols = {r[0] for r in db.conn.execute("DESCRIBE denormalized_nodes").fetchall()}
+        assert {"has_phenotype", "has_phenotype_label", "has_phenotype_count"}.issubset(n_cols)
+        assert "has_phenotype_closure" not in n_cols
+        assert "has_phenotype_closure_label" not in n_cols
+        assert not any(c.startswith("has_descendant") for c in n_cols)
+
+        # The closure side tables were never built.
+        tables = {r[0] for r in db.conn.execute("SHOW TABLES").fetchall()}
+        assert "closure_id" not in tables
+        assert "descendants_id" not in tables
+
+        # The views still read.
+        assert db.conn.execute("SELECT COUNT(*) FROM denormalized_edges").fetchone()[0] == 2
+
+
 def test_closurize_tolerates_unseeded_database(synthetic_kg):
     """If `_koza_schema` is absent (graphs from before the schema feature),
     closurize still produces the denormalized tables, it just skips the


### PR DESCRIPTION
Makes `closure_file` optional for the **closurize** operation so it can produce `denormalized_nodes` / `denormalized_edges` without a relation-graph closure.

When no closure file is supplied:
- `closure_id` / `closure_label` / `descendants_id` / `descendants_label` are never built.
- `denormalized_edges` is built without `*_closure` / `*_closure_label` columns, keeping `*_label` / `*_category` / `*_namespace` (+ taxon for subject/object).
- `denormalized_nodes` drops the per-field `*_closure` / `*_closure_label` columns and the node-level `has_descendant` / `has_descendant_label` / `has_descendant_count` slots.
- `evidence_count` and `grouping_key` are still materialized (closure-independent).

When `closure_file` is given, behavior is unchanged.

### Changes
- `ClosurizeConfig.closure_file: Path | None = None`; path-exists validator tolerates `None`.
- `_closurize_engine.add_closure(closure_file=None, ...)` threads an `include_closure` flag into the edges-view, nodes-view, and per-predicate side-table builders.
- `koza closurize` `--closure-file/-c` is now optional, with help text describing the no-closure shape.
- `_evolve_schema_for_denormalized` already rebuilds `DenormalizedEntity` / `DenormalizedAssociation` slot lists from the produced view columns, so no closure-slot special-casing is needed there.

### Tests
Existing closurize tests pass, plus a new `test_closurize_without_closure_file_omits_closure_slots` asserting the views build and read, and that no closure / descendant slots (or side tables) are produced.

Closes #220
