### PR TITLE
Preserve Biolink multivalued slots by default; make force-single-valued opt-in

### DIFF
--- a/src/koza/graph_operations/join.py
+++ b/src/koza/graph_operations/join.py
@@ -143,7 +143,11 @@ def join_graphs(config: JoinConfig) -> JoinResult:
                 if config.show_progress:
                     node_progress.set_description(f"Loading {file_spec.path.name}")
 
-                result = db.load_file(file_spec, generate_provided_by=config.generate_provided_by)
+                result = db.load_file(
+                    file_spec,
+                    generate_provided_by=config.generate_provided_by,
+                    force_single_valued=set(config.force_single_valued),
+                )
                 files_loaded.append(result)
 
                 if config.required_node_fields:
@@ -165,7 +169,11 @@ def join_graphs(config: JoinConfig) -> JoinResult:
                 if config.show_progress:
                     edge_progress.set_description(f"Loading {file_spec.path.name}")
 
-                result = db.load_file(file_spec, generate_provided_by=config.generate_provided_by)
+                result = db.load_file(
+                    file_spec,
+                    generate_provided_by=config.generate_provided_by,
+                    force_single_valued=set(config.force_single_valued),
+                )
                 files_loaded.append(result)
 
                 if config.required_edge_fields:

--- a/src/koza/graph_operations/merge.py
+++ b/src/koza/graph_operations/merge.py
@@ -136,6 +136,7 @@ def merge_graphs(config: MergeConfig) -> MergeResult:
             generate_provided_by=config.generate_provided_by,
             required_node_fields=config.required_node_fields,
             required_edge_fields=config.required_edge_fields,
+            force_single_valued=config.force_single_valued,
         )
 
         join_result = join_graphs(join_config)

--- a/src/koza/graph_operations/schema_utils.py
+++ b/src/koza/graph_operations/schema_utils.py
@@ -80,13 +80,12 @@ class SchemaParser:
         return {field for field in field_names if self.is_field_multivalued(field)}
 
 
-# Fields that should be treated as single-valued regardless of schema definition
-# (e.g., category, in_taxon, and type are multivalued in biolink but we treat them as single-valued)
-FORCE_SINGLE_VALUED_FIELDS: Set[str] = {
-    "category",
-    "in_taxon",
-    "type",
-}
+# koza preserves Biolink slot definitions by default. Collapsing a
+# Biolink-multivalued slot to a scalar is opt-in per call via the
+# `force_single_valued` argument; koza intentionally ships no built-in set of
+# fields to collapse, so it carries no downstream-specific policy. Consumers
+# that want a particular convention (e.g. monarch-app's scalar category /
+# in_taxon / type) pass their own list.
 
 # Global schema parser instance (lazy loaded)
 _global_schema_parser: Optional[SchemaParser] = None
@@ -110,19 +109,27 @@ def get_schema_parser(schema_path: Optional[str] = None) -> SchemaParser:
     return _global_schema_parser
 
 
-def is_field_multivalued(field_name: str, schema_path: Optional[str] = None) -> bool:
+def is_field_multivalued(
+    field_name: str,
+    schema_path: Optional[str] = None,
+    force_single_valued: Optional[Set[str]] = None,
+) -> bool:
     """
     Check if a field is multivalued, using schema if available or fallback list.
 
     Args:
         field_name: Field name to check
         schema_path: Optional schema path (uses cached parser if None)
+        force_single_valued: Slot names the caller has explicitly opted into
+            single-valued collapse. A field in this set is reported
+            single-valued regardless of its Biolink definition. Default: none —
+            Biolink slot definitions are preserved.
 
     Returns:
         True if field is multivalued, False otherwise
     """
-    # Check if field is forced to be single-valued
-    if field_name in FORCE_SINGLE_VALUED_FIELDS:
+    # Honor caller-requested single-valued overrides only.
+    if force_single_valued and field_name in force_single_valued:
         return False
 
     parser = get_schema_parser(schema_path)
@@ -132,13 +139,19 @@ def is_field_multivalued(field_name: str, schema_path: Optional[str] = None) -> 
     return False
 
 
-def get_multivalued_columns(column_names: list[str], schema_path: Optional[str] = None) -> Set[str]:
+def get_multivalued_columns(
+    column_names: list[str],
+    schema_path: Optional[str] = None,
+    force_single_valued: Optional[Set[str]] = None,
+) -> Set[str]:
     """
     Identify which columns from a list are multivalued.
 
     Args:
         column_names: List of column names to check
         schema_path: Optional schema path
+        force_single_valued: Slot names explicitly opted into single-valued
+            collapse (excluded from the multivalued result).
 
     Returns:
         Set of column names that are multivalued
@@ -146,7 +159,7 @@ def get_multivalued_columns(column_names: list[str], schema_path: Optional[str] 
     multivalued = set()
 
     for col in column_names:
-        if is_field_multivalued(col, schema_path):
+        if is_field_multivalued(col, schema_path, force_single_valued):
             multivalued.add(col)
 
     return multivalued

--- a/src/koza/graph_operations/utils.py
+++ b/src/koza/graph_operations/utils.py
@@ -17,13 +17,14 @@ from koza.model.graph_operations import (
     KGXFormat,
     OperationSummary,
 )
-from koza.graph_operations.schema_utils import get_multivalued_columns, FORCE_SINGLE_VALUED_FIELDS
+from koza.graph_operations.schema_utils import get_multivalued_columns
 
 
 def _generate_multivalued_select(
     conn: duckdb.DuckDBPyConnection,
     temp_table: str,
     multivalued_columns: set[str],
+    force_single_valued: set[str],
 ) -> str:
     """
     Generate a SELECT statement that transforms pipe-delimited multivalued fields into arrays.
@@ -32,6 +33,9 @@ def _generate_multivalued_select(
         conn: DuckDB connection
         temp_table: Name of temporary table to read from
         multivalued_columns: Set of column names that should be converted to arrays
+        force_single_valued: Set of column names the caller has opted into
+            single-valued collapse (array -> first element). Empty by default,
+            so Biolink-multivalued slots are preserved as arrays.
 
     Returns:
         SQL SELECT statement with appropriate column transformations
@@ -42,9 +46,10 @@ def _generate_multivalued_select(
     # Build SELECT clause with conditional column transformation
     select_parts = []
     for col_name, col_type, *_ in columns_result:
-        if col_name in FORCE_SINGLE_VALUED_FIELDS and col_type == "VARCHAR[]":
-            # Flatten array to single value for fields forced to be single-valued
-            # (e.g., JSONL has category as ["biolink:X"] but we need it as "biolink:X")
+        if col_name in force_single_valued and col_type == "VARCHAR[]":
+            # Flatten array to single value for fields the caller opted into
+            # single-valued (e.g., JSONL has category as ["biolink:X"] and the
+            # caller wants "biolink:X"). Only the first element is kept.
             select_parts.append(f"""
                 CASE
                     WHEN "{col_name}" IS NULL OR len("{col_name}") = 0 THEN NULL
@@ -210,7 +215,12 @@ class GraphDatabase:
 
         logger.info("Database schema initialized (main tables created dynamically)")
 
-    def load_file(self, file_spec: FileSpec, generate_provided_by: bool = True) -> FileLoadResult:
+    def load_file(
+        self,
+        file_spec: FileSpec,
+        generate_provided_by: bool = True,
+        force_single_valued: set[str] | None = None,
+    ) -> FileLoadResult:
         """
         Load a KGX file into a temporary table for schema analysis.
 
@@ -218,6 +228,9 @@ class GraphDatabase:
             file_spec: FileSpec describing the file to load
             generate_provided_by: If True, add provided_by column from filename (like cat-merge).
                                   Any existing provided_by column in the input file will be replaced.
+            force_single_valued: Slot names to collapse from arrays to scalars
+                                  (keeping the first element). Empty/None preserves
+                                  Biolink multivalued slots as arrays.
 
         Returns:
             FileLoadResult with load statistics
@@ -291,13 +304,17 @@ class GraphDatabase:
             # Transform pipe-delimited multivalued fields to arrays
             # Skip file_source and provided_by (when generated) since we add them as literals.
             # When the user supplied explicit slots, the column types already reflect
-            # Biolink's multivalued declarations; the FORCE_SINGLE_VALUED flatten path
+            # Biolink's multivalued declarations; the single-valued flatten path
             # would undo that, so skip the transform entirely.
             if not file_spec.slots:
                 skip_columns = {"file_source"}
                 if generate_provided_by:
                     skip_columns.add("provided_by")
-                self._transform_multivalued_columns(temp_table_name, skip_columns=skip_columns)
+                self._transform_multivalued_columns(
+                    temp_table_name,
+                    skip_columns=skip_columns,
+                    force_single_valued=force_single_valued,
+                )
 
             # Get record count
             count_result = self.conn.execute(f"SELECT COUNT(*) FROM {temp_table_name}").fetchone()
@@ -341,16 +358,27 @@ class GraphDatabase:
                 errors=errors,
             )
 
-    def _transform_multivalued_columns(self, temp_table_name: str, skip_columns: set[str] | None = None):
+    def _transform_multivalued_columns(
+        self,
+        temp_table_name: str,
+        skip_columns: set[str] | None = None,
+        force_single_valued: set[str] | None = None,
+    ):
         """
         Transform pipe-delimited VARCHAR columns to VARCHAR[] arrays for known multivalued fields,
-        and flatten VARCHAR[] columns to VARCHAR for force-single-valued fields (e.g. from JSONL input).
+        and flatten VARCHAR[] columns to VARCHAR for caller-opted single-valued fields.
+
+        By default Biolink slot definitions are preserved (nothing is flattened);
+        only fields named in `force_single_valued` are collapsed.
 
         Args:
             temp_table_name: Name of the temporary table to transform
             skip_columns: Set of column names to skip (e.g., columns we added as literals)
+            force_single_valued: Slot names the caller explicitly opted into
+                single-valued collapse. Empty/None preserves all arrays.
         """
         skip_columns = skip_columns or set()
+        force_single_valued = force_single_valued or set()
 
         try:
             # Get column info from the temp table
@@ -358,20 +386,26 @@ class GraphDatabase:
             column_names = [row[0] for row in describe_result if row[0] not in skip_columns]
             column_types = {row[0]: row[1] for row in describe_result if row[0] not in skip_columns}
 
-            # Identify which columns are multivalued
-            multivalued_cols = get_multivalued_columns(column_names)
+            # Identify which columns are multivalued (excluding caller-forced single-valued)
+            multivalued_cols = get_multivalued_columns(column_names, force_single_valued=force_single_valued)
 
-            # Check if any force-single-valued fields arrived as arrays (e.g. from JSONL)
-            needs_flattening = any(
-                col in FORCE_SINGLE_VALUED_FIELDS and column_types.get(col) == "VARCHAR[]"
-                for col in column_names
-            )
+            # Check if any caller-opted single-valued fields arrived as arrays (e.g. from JSONL)
+            fields_to_flatten = [
+                col for col in column_names
+                if col in force_single_valued and column_types.get(col) == "VARCHAR[]"
+            ]
 
-            if not multivalued_cols and not needs_flattening:
+            if not multivalued_cols and not fields_to_flatten:
                 return
 
+            # Warn before any lossy collapse: flattening keeps only the first
+            # array element, so any row with >1 value loses data.
+            self._warn_on_lossy_flatten(temp_table_name, fields_to_flatten)
+
             # Generate SELECT with transformations
-            select_sql = _generate_multivalued_select(self.conn, temp_table_name, multivalued_cols)
+            select_sql = _generate_multivalued_select(
+                self.conn, temp_table_name, multivalued_cols, force_single_valued
+            )
 
             # Recreate the table with transformed columns
             self.conn.execute(f"""
@@ -383,10 +417,35 @@ class GraphDatabase:
             logger.debug(
                 f"Transformed {len(multivalued_cols)} multivalued columns in {temp_table_name}: "
                 f"{', '.join(sorted(multivalued_cols))}"
+                + (
+                    f"; flattened to single-valued: {', '.join(sorted(fields_to_flatten))}"
+                    if fields_to_flatten else ""
+                )
             )
 
         except Exception as e:
             logger.warning(f"Failed to transform multivalued columns in {temp_table_name}: {e}")
+
+    def _warn_on_lossy_flatten(self, temp_table_name: str, fields_to_flatten: list[str]) -> None:
+        """Warn when a force-single-valued collapse would discard data.
+
+        Flattening keeps only the first element of each array, so any row whose
+        array has more than one value silently loses the rest. Surface that as a
+        warning rather than dropping data quietly.
+        """
+        for col in fields_to_flatten:
+            try:
+                lost = self.conn.execute(
+                    f'SELECT COUNT(*) FROM {temp_table_name} '
+                    f'WHERE len("{col}") > 1'
+                ).fetchone()[0]
+            except Exception:  # pragma: no cover - defensive; don't block the load
+                continue
+            if lost:
+                logger.warning(
+                    f"force_single_valued: collapsing '{col}' to a scalar discards "
+                    f"additional values in {lost:,} row(s) (only the first element is kept)."
+                )
 
     def _analyze_file_schema(self, file_spec: FileSpec, temp_table_name: str):
         """Analyze and store schema information for a loaded file."""

--- a/src/koza/main.py
+++ b/src/koza/main.py
@@ -342,6 +342,18 @@ def join(
             ),
         ),
     ] = None,
+    force_single_valued: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--force-single-valued",
+            help=(
+                "Collapse this Biolink-multivalued slot to a scalar, keeping only "
+                "the first array element (repeatable). Default: none — Biolink "
+                "multivalued slots are preserved as arrays. Pass e.g. "
+                "--force-single-valued category for the historical Monarch convention."
+            ),
+        ),
+    ] = None,
     quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress output")] = False,
     show_progress: Annotated[bool, typer.Option("--progress", "-p", help="Show progress bars")] = True,
 ) -> None:
@@ -417,6 +429,7 @@ def join(
             required_node_fields=required_node_fields or [],
             required_edge_fields=required_edge_fields or [],
             slots_file=Path(slots_file) if slots_file else None,
+            force_single_valued=force_single_valued or [],
             quiet=quiet,
             show_progress=show_progress,
         )
@@ -885,6 +898,17 @@ def merge(
         list[str] | None,
         typer.Option("--required-edge-field", help="Edge fields that must be present and non-empty (can specify multiple)"),
     ] = None,
+    force_single_valued: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--force-single-valued",
+            help=(
+                "Collapse this Biolink-multivalued slot to a scalar during the join "
+                "step, keeping only the first array element (repeatable). Default: "
+                "none — Biolink multivalued slots are preserved as arrays."
+            ),
+        ),
+    ] = None,
     quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress output")] = False,
     show_progress: Annotated[bool, typer.Option("--progress", "-p", help="Show progress bars")] = True,
 ) -> None:
@@ -1009,6 +1033,7 @@ def merge(
             graph_name=graph_name,
             required_node_fields=required_node_fields or [],
             required_edge_fields=required_edge_fields or [],
+            force_single_valued=force_single_valued or [],
             quiet=quiet,
             show_progress=show_progress,
         )

--- a/src/koza/model/graph_operations.py
+++ b/src/koza/model/graph_operations.py
@@ -109,6 +109,11 @@ class JoinConfig(GraphOperationConfig):
     required_edge_fields: list[str] = Field(default_factory=list)
     seed_schema: bool = True  # Seed the koza graph schema (derived-schema.yaml + Biolink) into DuckDB metadata
     slots_file: Path | None = None  # YAML file with {nodes: [...], edges: [...]} — applies explicit JSONL schemas to all files in the join
+    # Slot names to collapse from arrays to scalars (keeping the first element).
+    # Empty by default: koza preserves Biolink multivalued slot definitions.
+    # Opt in per field, e.g. ["category", "in_taxon", "type"] to match consumers
+    # (like monarch-app) that expect those slots scalar.
+    force_single_valued: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def set_database_path_from_output_database(self):
@@ -324,6 +329,9 @@ class MergeConfig(BaseModel):
     continue_on_pipeline_step_error: bool = True # If there is an error for a non-critical pipeline step, append a warning and continue the merge.
     required_node_fields: list[str] = Field(default_factory=list)
     required_edge_fields: list[str] = Field(default_factory=list)
+    # Slot names to collapse from arrays to scalars during the join step.
+    # Empty by default: Biolink multivalued slot definitions are preserved.
+    force_single_valued: list[str] = Field(default_factory=list)
 
     # Prune-specific options
     keep_singletons: bool = True

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -1234,5 +1234,79 @@ class TestApplySlotsFile:
             _apply_slots_file(_conf("edges: [id, 42, predicate]\n"))
 
 
+class TestForceSingleValued:
+    """Biolink multivalued slots are preserved by default; the single-valued
+    collapse is opt-in via force_single_valued."""
+
+    @pytest.fixture
+    def array_category_jsonl(self, temp_dir):
+        """Nodes/edges with canonical Biolink array `category` and a node with
+        two categories (to exercise the lossy-collapse path)."""
+        nodes = temp_dir / "fsv_nodes.jsonl"
+        nodes.write_text(
+            '{"id": "CHEBI:1", "category": ["biolink:ChemicalEntity"], "name": "c1"}\n'
+            '{"id": "HGNC:1", "category": ["biolink:Gene", "biolink:NamedThing"], "name": "g1"}\n'
+        )
+        edges = temp_dir / "fsv_edges.jsonl"
+        edges.write_text(
+            '{"id": "e1", "subject": "CHEBI:1", "predicate": "biolink:related_to", '
+            '"object": "HGNC:1", "category": ["biolink:Association"]}\n'
+        )
+        return nodes, edges
+
+    def _describe(self, db_path, table):
+        import duckdb
+        with duckdb.connect(str(db_path)) as conn:
+            return {r[0]: r[1] for r in conn.execute(f"DESCRIBE {table}").fetchall()}
+
+    def test_default_preserves_array_category(self, array_category_jsonl, temp_dir):
+        """No force_single_valued: array `category` stays VARCHAR[]."""
+        nodes, edges = array_category_jsonl
+        db_path = temp_dir / "preserved.duckdb"
+        result = join_graphs(JoinConfig(
+            node_files=[FileSpec(path=nodes, format=KGXFormat.JSONL, file_type=KGXFileType.NODES)],
+            edge_files=[FileSpec(path=edges, format=KGXFormat.JSONL, file_type=KGXFileType.EDGES)],
+            database_path=db_path, quiet=True, show_progress=False,
+        ))
+        assert result.final_stats.nodes == 2
+        assert self._describe(db_path, "nodes")["category"] == "VARCHAR[]"
+        assert self._describe(db_path, "edges")["category"] == "VARCHAR[]"
+
+    def test_force_single_valued_collapses_category(self, array_category_jsonl, temp_dir):
+        """With force_single_valued=['category'], category flattens to scalar."""
+        nodes, edges = array_category_jsonl
+        db_path = temp_dir / "collapsed.duckdb"
+        join_graphs(JoinConfig(
+            node_files=[FileSpec(path=nodes, format=KGXFormat.JSONL, file_type=KGXFileType.NODES)],
+            edge_files=[FileSpec(path=edges, format=KGXFormat.JSONL, file_type=KGXFileType.EDGES)],
+            database_path=db_path, force_single_valued=["category"],
+            quiet=True, show_progress=False,
+        ))
+        assert self._describe(db_path, "nodes")["category"] == "VARCHAR"
+        assert self._describe(db_path, "edges")["category"] == "VARCHAR"
+
+        import duckdb
+        with duckdb.connect(str(db_path)) as conn:
+            cat = conn.execute("SELECT category FROM nodes WHERE id = 'HGNC:1'").fetchone()[0]
+        # Only the first element survives the collapse.
+        assert cat == "biolink:Gene"
+
+    def test_lossy_collapse_warns(self, array_category_jsonl, temp_dir, caplog):
+        """Collapsing a slot that has multi-element arrays warns about data loss."""
+        import logging
+        nodes, edges = array_category_jsonl
+        db_path = temp_dir / "warn.duckdb"
+        with caplog.at_level(logging.WARNING):
+            join_graphs(JoinConfig(
+                node_files=[FileSpec(path=nodes, format=KGXFormat.JSONL, file_type=KGXFileType.NODES)],
+                edge_files=[FileSpec(path=edges, format=KGXFormat.JSONL, file_type=KGXFileType.EDGES)],
+                database_path=db_path, force_single_valued=["category"],
+                quiet=True, show_progress=False,
+            ))
+        # HGNC:1 has two categories — its collapse is lossy.
+        assert any("force_single_valued" in r.message and "category" in r.message
+                   for r in caplog.records)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Reverses koza's default handling of the Biolink-multivalued slots `category`, `in_taxon`, and `type`, per #219.

### Before
`koza join` (and the load path under `merge`) silently collapsed these three slots from arrays to scalars — keeping only `array[1]` — with **no opt-out flag** and **no warning**. Lossless only when every array had length 1; otherwise it dropped data silently. It also meant a KGX file no longer round-tripped its own `category` shape (`VARCHAR[]` in → `VARCHAR` out).

### After
- **Default preserves Biolink slot definitions.** Array-valued `category` / `in_taxon` / `type` stay `VARCHAR[]`.
- **Collapse is opt-in** via a new `force_single_valued` list:
  - CLI: repeatable `--force-single-valued <field>` on `join` and `merge`.
  - Python: `JoinConfig` / `MergeConfig` field, also accepted as a kwarg through `prepare_merge_config_from_paths` (so `merge_graphs` callers like monarch-ingest can opt in without signature changes).
- **Lossy collapse warns.** If a requested field has any array with >1 element, a warning names the field and row count instead of silently discarding.
- **koza ships no built-in single-valued set.** The mechanism is generic; which slots to collapse is the consumer's policy (e.g. monarch-ingest passes `["category", "in_taxon", "type"]`). koza no longer encodes a Monarch-specific list.

### Migration note for downstream
Pipelines that relied on the old scalar default (e.g. monarch-ingest, which calls `merge_graphs` and currently passes nothing) should add `force_single_valued=["category", "in_taxon", "type"]` to keep scalar `category` / `in_taxon` / `type`.

### Implementation
- `schema_utils.py`: `is_field_multivalued` / `get_multivalued_columns` take an explicit `force_single_valued` set; the hardcoded default-forcing is gone.
- `utils.py`: `load_file` → `_transform_multivalued_columns` → `_generate_multivalued_select` thread the set through; new `_warn_on_lossy_flatten`.
- `join.py` / `merge.py`: pass the config field down.
- `model/graph_operations.py`: `force_single_valued: list[str]` on `JoinConfig` and `MergeConfig`.
- `main.py`: `--force-single-valued` on `join` and `merge`.

### Tests
Full suite green (399 passed, 10 skipped). New `TestForceSingleValued` covers: default preserves `VARCHAR[]`, opt-in collapses to `VARCHAR` keeping the first element, and the lossy-collapse warning fires on a two-category node.

### Downstream verification
Paired against monarch-ingest (its `merge_graphs` call + `force_single_valued=["category","in_taxon","type"]`): merge succeeds and produces scalar `category`, keeping monarch-ingest's category-dependent SQL working; without the opt-in, that SQL fails — confirming the migration step is necessary and sufficient.

Closes #219
