### PR TITLE
ci: unblock uv lock by dropping quarantined ensmallen/embiggen extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,23 @@ dependencies = [
     "LinkML>=1.9.0"
 ]
 
+# NOTE: `ensmallen` and `embiggen` are temporarily removed from the extras
+# below. Both were quarantined on PyPI during the mini-Shai-Hulud supply-chain
+# wave (their /simple/ pages return project-status "quarantined" with zero
+# downloadable files for ALL versions), which makes `uv lock` unsatisfiable and
+# breaks CI for every PR. Restore the pins once PyPI de-quarantines them (or the
+# maintainers cut clean releases). Until then, the connectivity report's
+# ensmallen import degrades gracefully via `_check_ensmallen_available()`; users
+# who need it must install ensmallen manually from a trusted source.
 [project.optional-dependencies]
 grape = [
-    "ensmallen==0.8.99",
+    # "ensmallen==0.8.99",  # quarantined on PyPI — see note above
     "pandas",
     "pyarrow",
 ]
 ml = [
-    "ensmallen==0.8.99",
-    "embiggen>=0.11",
+    # "ensmallen==0.8.99",  # quarantined on PyPI — see note above
+    # "embiggen>=0.11",     # quarantined on PyPI (pulls ensmallen) — see note above
     "pandas",
     "pyarrow",
 ]


### PR DESCRIPTION
## Problem

CI is red on **every** open PR (and would be on `main`), failing in ~15s at `make install` before any test runs:

```
Because there is no version of ensmallen==0.8.99 and koza[grape] depends
on ensmallen==0.8.99 ... your project's requirements are unsatisfiable.
make: *** [Makefile:30: install] Error 1
```

`ensmallen` (and `embiggen`, which pulls it transitively) were **quarantined on PyPI** during the mini-Shai-Hulud supply-chain wave. Their `/simple/` index pages now report:

```
<meta name="pypi:project-status" content="quarantined">
```

with **zero** downloadable files for *every* version — so there's no earlier version to pin to. Because `make install` runs `uv lock`, which resolves *all* optional-dependency extras, the unsatisfiable `ensmallen` pin in the `grape`/`ml` extras makes the lock fail and takes CI down for all PRs.

## Fix

Comment out the quarantined pins (`ensmallen` in `grape`/`ml`, `embiggen` in `ml`), keeping `pandas`/`pyarrow`. `uv lock` resolves again and CI goes green.

This is safe because the only consumer, the connectivity/topology report, already guards the import:
- `connectivity.py:_check_ensmallen_available()` (try/except ImportError) and a function-local `from ensmallen import Graph`,
- its tests skip when ensmallen is absent.

Users who need the connectivity report can install `ensmallen` manually from a trusted source until PyPI de-quarantines it.

## Verification

`make install` → `uv lock --check` → `make test` all pass locally: **396 passed, 10 skipped** (the skips are the connectivity tests degrading gracefully). `ensmallen`/`embiggen` no longer appear in the resolved lock.

## Follow-up

Revert this once PyPI clears the quarantine (or the GRAPE maintainers cut clean releases) to restore the connectivity/ML extras. A `# quarantined on PyPI` comment marks each line to un-comment.
