### PR TITLE
Add a 'load' verb for faithful single-step KG ingest

### DIFF
--- a/src/koza/graph_operations/CONTEXT.md
+++ b/src/koza/graph_operations/CONTEXT.md
@@ -1,6 +1,6 @@
 # Graph Operations Context
 
-Terminology for koza's graph operations package, which wraps DuckDB to perform KGX-format graph transforms (join, deduplicate, normalize, prune, split, append, merge, report) behind a Python CLI.
+Terminology for koza's graph operations package, which wraps DuckDB to perform KGX-format graph transforms (load, join, deduplicate, normalize, prune, split, append, merge, report) behind a Python CLI.
 
 ## Language
 
@@ -45,8 +45,12 @@ A module-level constant (`DECLARED_OUTPUTS`) on each operation module that lists
 _Avoid_: produced slots, output schema, operation contract.
 
 **Operation**:
-One of the high-level graph transforms exposed by the CLI: join, deduplicate, normalize, prune, split, append, merge, closurize, report. Each is a module under `koza/graph_operations/`.
+One of the high-level graph transforms exposed by the CLI: load, join, deduplicate, normalize, prune, split, append, merge, closurize, report. Each is a module under `koza/graph_operations/`.
 _Avoid_: command, action, transform (transform refers to the koza ingest side).
+
+**Load** / **Join**:
+Both ingest KGX node/edge files into the `nodes` / `edges` tables — the first step of building a graph database. They differ in provenance handling, not mechanism: `load` brings an existing graph in faithfully (preserves `provided_by`, no schema report by default), while `join` is cat-merge style for building from raw per-source files (stamps `provided_by` from the source filename, oriented toward combining many files). `load` is `join_graphs` with `LoadConfig`'s defaults (`generate_provided_by=False`, `schema_reporting=False`); use it when a knowledge graph is already represented as node/edge files and you just want it in DuckDB for analysis or downstream operations without a full `merge`.
+_Avoid_: import (names the koza ingest/reader side), ingest (that's the transform stage).
 
 **Closurize**:
 The operation that applies a relation-graph closure to a merged graph database. Produces `denormalized_nodes` and `denormalized_edges` as VIEWs over base tables (~50% smaller DuckDB than the historical materialized shape), plus per-predicate node-extension side tables and the materialized `closure_id` / `closure_label` / `descendants_id` / `descendants_label` tables. Evolves the stored schema to include `DenormalizedEntity` / `DenormalizedAssociation` classes whose slot lists come from the actual produced views. Migrated from the `closurizer` package in May 2026; this module is now its canonical home, the standalone package is no longer maintained.

--- a/src/koza/graph_operations/__init__.py
+++ b/src/koza/graph_operations/__init__.py
@@ -10,6 +10,7 @@ from .closurize import closurize_graph
 from .connectivity import generate_connectivity_report
 from .deduplicate import deduplicate_graph
 from .join import join_graphs, prepare_file_specs_from_paths
+from .load import load_graph, prepare_load_config_from_paths
 from .merge import merge_graphs, prepare_merge_config_from_paths
 from .normalize import normalize_graph, prepare_mapping_file_specs_from_paths
 from .prune import prune_graph
@@ -28,6 +29,8 @@ from .utils import GraphDatabase, print_operation_summary
 
 __all__ = [
     "join_graphs",
+    "load_graph",
+    "prepare_load_config_from_paths",
     "split_graph",
     "prune_graph",
     "append_graphs",

--- a/src/koza/graph_operations/load.py
+++ b/src/koza/graph_operations/load.py
@@ -1,0 +1,53 @@
+"""Load operation: faithfully ingest KGX node/edge files into a DuckDB.
+
+`load` is the first step of a build on its own — get a knowledge graph that is
+already represented as node and edge files into `nodes` / `edges` tables, ready
+for analysis or downstream operations (`closurize`, `report`, ...), without the
+deduplicate / normalize / prune stages that `merge` runs.
+
+Mechanically it is `join` with faithful-load defaults (preserve `provided_by`
+instead of stamping it from the source filename, and skip the schema report),
+so this module is a thin, intent-revealing wrapper over `join_graphs`. The
+distinction is semantic: `join`/`merge` build a graph from raw per-source files
+(cat-merge style); `load` brings an existing graph in as-is.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from koza.model.graph_operations import JoinResult, LoadConfig
+
+from .join import join_graphs, prepare_file_specs_from_paths
+
+
+def load_graph(config: LoadConfig) -> JoinResult:
+    """Load KGX node/edge files into a DuckDB as `nodes` / `edges` tables.
+
+    A thin wrapper over `join_graphs` that uses `LoadConfig`'s faithful-load
+    defaults. Returns the same `JoinResult` as `join_graphs`.
+    """
+    return join_graphs(config)
+
+
+def prepare_load_config_from_paths(
+    node_files: list[Path],
+    edge_files: list[Path],
+    output_database: Path | None = None,
+    **kwargs,
+) -> LoadConfig:
+    """Build a `LoadConfig` from node/edge file paths, auto-generating FileSpecs.
+
+    Mirrors `prepare_merge_config_from_paths`: formats and file types are
+    auto-detected from the paths, and any extra `LoadConfig` options pass
+    through via `kwargs` (e.g. `quiet`, `show_progress`, `slots_file`).
+    """
+    node_specs, edge_specs = prepare_file_specs_from_paths(
+        [str(f) for f in node_files], [str(f) for f in edge_files]
+    )
+    return LoadConfig(
+        node_files=node_specs,
+        edge_files=edge_specs,
+        output_database=output_database,
+        **kwargs,
+    )

--- a/src/koza/main.py
+++ b/src/koza/main.py
@@ -22,9 +22,11 @@ from koza.graph_operations import (
     generate_qc_report,
     generate_schema_compliance_report,
     join_graphs,
+    load_graph,
     merge_graphs,
     normalize_graph,
     prepare_file_specs_from_paths,
+    prepare_load_config_from_paths,
     prepare_mapping_file_specs_from_paths,
     prepare_merge_config_from_paths,
     prune_graph,
@@ -426,6 +428,129 @@ def join(
 
         if not quiet:
             typer.echo("Join operation completed successfully!")
+
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@typer_app.command()
+def load(
+    node_files: Annotated[
+        list[str] | None, typer.Option("--nodes", "-n", help="Node files or glob patterns (can specify multiple)")
+    ] = None,
+    edge_files: Annotated[
+        list[str] | None, typer.Option("--edges", "-e", help="Edge files or glob patterns (can specify multiple)")
+    ] = None,
+    input_directory: Annotated[
+        str | None, typer.Option("--input-dir", "-d", help="Directory to auto-discover KGX files")
+    ] = None,
+    output_database: Annotated[
+        str | None, typer.Option("--output", "-o", help="Path to output database file (default: in-memory)")
+    ] = None,
+    output_format: Annotated[
+        KGXFormat, typer.Option("--format", "-f", help="Output format for any exported files")
+    ] = KGXFormat.TSV,
+    slots_file: Annotated[
+        str | None,
+        typer.Option(
+            "--slots-file",
+            help=(
+                "YAML file with {nodes: [...], edges: [...]} — sets explicit JSONL "
+                "schema, skipping inference. JSON keys NOT in the slot list are "
+                "silently dropped at read time."
+            ),
+        ),
+    ] = None,
+    required_node_fields: Annotated[
+        list[str] | None,
+        typer.Option("--required-node-field", help="Node fields that must be present and non-empty (can specify multiple)"),
+    ] = None,
+    required_edge_fields: Annotated[
+        list[str] | None,
+        typer.Option("--required-edge-field", help="Edge fields that must be present and non-empty (can specify multiple)"),
+    ] = None,
+    generate_provided_by: Annotated[
+        bool,
+        typer.Option(
+            "--generate-provided-by",
+            help="Overwrite provided_by with the source filename (cat-merge style). "
+                 "Off by default: load preserves any existing provided_by.",
+        ),
+    ] = False,
+    schema_reporting: Annotated[
+        bool, typer.Option("--schema-report", help="Generate schema compliance report")
+    ] = False,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress output")] = False,
+    show_progress: Annotated[bool, typer.Option("--progress", "-p", help="Show progress bars")] = True,
+) -> None:
+    """Load KGX node/edge files into a DuckDB as-is.
+
+    The first step of a build, on its own: bring a knowledge graph that is
+    already represented as node and edge files into `nodes` / `edges` tables,
+    ready for analysis or downstream operations (closurize, report) — without
+    the deduplicate / normalize / prune stages that `merge` runs.
+
+    Unlike `join` (cat-merge style), `load` preserves an existing `provided_by`
+    instead of overwriting it with the source filename. Pass
+    `--generate-provided-by` to opt into the filename-stamping behavior.
+
+    Examples:
+        # Load a KG represented as one nodes file and one edges file
+        koza load -n graph_nodes.jsonl -e graph_edges.jsonl -o graph.duckdb
+
+        # Auto-discover from a directory
+        koza load --input-dir kg/ -o graph.duckdb
+    """
+    try:
+        # Collect all node and edge files (mirrors `join`'s input handling)
+        all_node_files: list[str] = []
+        all_edge_files: list[str] = []
+
+        if input_directory:
+            discovered_nodes, discovered_edges = _discover_files_in_directory(Path(input_directory))
+            all_node_files.extend(discovered_nodes)
+            all_edge_files.extend(discovered_edges)
+            if not quiet:
+                print(f"📂 Auto-discovered from {input_directory}:")
+                print(f"   - {len(discovered_nodes)} node files")
+                print(f"   - {len(discovered_edges)} edge files")
+
+        if node_files:
+            all_node_files.extend(_expand_file_patterns(node_files))
+        if edge_files:
+            all_edge_files.extend(_expand_file_patterns(edge_files))
+
+        # Remove duplicates while preserving order
+        all_node_files = list(dict.fromkeys(all_node_files))
+        all_edge_files = list(dict.fromkeys(all_edge_files))
+
+        if not all_node_files and not all_edge_files:
+            if input_directory:
+                raise typer.BadParameter(f"No KGX files found in directory: {input_directory}")
+            raise typer.BadParameter("Must specify --input-dir, --nodes, or --edges")
+
+        config = prepare_load_config_from_paths(
+            node_files=[Path(f) for f in all_node_files],
+            edge_files=[Path(f) for f in all_edge_files],
+            output_database=Path(output_database) if output_database else None,
+            output_format=output_format,
+            slots_file=Path(slots_file) if slots_file else None,
+            required_node_fields=required_node_fields or [],
+            required_edge_fields=required_edge_fields or [],
+            generate_provided_by=generate_provided_by,
+            schema_reporting=schema_reporting,
+            quiet=quiet,
+            show_progress=show_progress,
+        )
+
+        result = load_graph(config)
+
+        if not quiet:
+            typer.echo(
+                f"Load completed: {result.final_stats.nodes:,} nodes, "
+                f"{result.final_stats.edges:,} edges"
+            )
 
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)

--- a/src/koza/model/graph_operations.py
+++ b/src/koza/model/graph_operations.py
@@ -118,6 +118,29 @@ class JoinConfig(GraphOperationConfig):
         return self
 
 
+class LoadConfig(JoinConfig):
+    """Configuration for the load operation.
+
+    Load one or more KGX node/edge files into a DuckDB as `nodes` and `edges`
+    tables — the first step of a build, on its own (no deduplicate / normalize /
+    prune). Use this when a knowledge graph is already represented as node and
+    edge files and you just want it in DuckDB for analysis or downstream
+    operations like `closurize` / `report`.
+
+    Differs from `JoinConfig` only in defaults, reflecting a faithful as-is
+    load rather than a cat-merge-style build:
+    - `generate_provided_by` is False, so an existing `provided_by` is preserved
+      instead of being overwritten with the source filename.
+    - `schema_reporting` is False (no schema report written by default).
+
+    Inherits everything else from `JoinConfig`, so `load_graph` is just
+    `join_graphs` with these defaults.
+    """
+
+    generate_provided_by: bool = False
+    schema_reporting: bool = False
+
+
 class SplitConfig(GraphOperationConfig):
     """Configuration for split operation"""
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,139 @@
+"""Tests for the load operation — a faithful single-step load of KGX node/edge
+files into a DuckDB, as opposed to the cat-merge-style `join`.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from koza.graph_operations import join_graphs, load_graph, prepare_load_config_from_paths
+from koza.model.graph_operations import (
+    FileSpec,
+    JoinConfig,
+    KGXFileType,
+    KGXFormat,
+    LoadConfig,
+)
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+@pytest.fixture
+def kg_with_provided_by(temp_dir):
+    """A KG already carrying its own `provided_by` provenance — the case where
+    `join`'s filename-stamping would clobber it but `load` should preserve it."""
+    nodes = temp_dir / "mykg_nodes.jsonl"
+    nodes.write_text(
+        '{"id": "HGNC:1", "category": "biolink:Gene", "name": "g1", "provided_by": "upstream_source"}\n'
+        '{"id": "MONDO:1", "category": "biolink:Disease", "name": "d1", "provided_by": "upstream_source"}\n'
+    )
+    edges = temp_dir / "mykg_edges.jsonl"
+    edges.write_text(
+        '{"id": "e1", "subject": "HGNC:1", "predicate": "biolink:related_to", '
+        '"object": "MONDO:1", "category": "biolink:Association", "provided_by": "upstream_source"}\n'
+    )
+    return nodes, edges
+
+
+def _provided_by(db_path, table):
+    """Distinct provided_by values as a flat set. `provided_by` is Biolink
+    multivalued, so a preserved value can land as a 1-element array; flatten so
+    the test compares value content, not array/scalar wrapping."""
+    with duckdb.connect(str(db_path), read_only=True) as c:
+        cols = [r[0] for r in c.execute(f"DESCRIBE {table}").fetchall()]
+        if "provided_by" not in cols:
+            return None
+        rows = [r[0] for r in c.execute(f"SELECT DISTINCT provided_by FROM {table}").fetchall()]
+    flat = set()
+    for v in rows:
+        if isinstance(v, list):
+            flat.update(v)
+        elif v is not None:
+            flat.add(v)
+    return flat
+
+
+def test_load_creates_nodes_and_edges(kg_with_provided_by, temp_dir):
+    nodes, edges = kg_with_provided_by
+    db = temp_dir / "out.duckdb"
+    result = load_graph(LoadConfig(
+        node_files=[FileSpec(path=nodes, format=KGXFormat.JSONL, file_type=KGXFileType.NODES)],
+        edge_files=[FileSpec(path=edges, format=KGXFormat.JSONL, file_type=KGXFileType.EDGES)],
+        output_database=db, quiet=True, show_progress=False,
+    ))
+    assert result.final_stats.nodes == 2
+    assert result.final_stats.edges == 1
+    with duckdb.connect(str(db), read_only=True) as c:
+        tables = {r[0] for r in c.execute("SHOW TABLES").fetchall()}
+    assert {"nodes", "edges"}.issubset(tables)
+
+
+def test_load_preserves_provided_by(kg_with_provided_by, temp_dir):
+    """load defaults to generate_provided_by=False — existing provided_by survives."""
+    nodes, edges = kg_with_provided_by
+    db = temp_dir / "load.duckdb"
+    load_graph(LoadConfig(
+        node_files=[FileSpec(path=nodes, format=KGXFormat.JSONL, file_type=KGXFileType.NODES)],
+        edge_files=[FileSpec(path=edges, format=KGXFormat.JSONL, file_type=KGXFileType.EDGES)],
+        output_database=db, quiet=True, show_progress=False,
+    ))
+    assert _provided_by(db, "nodes") == {"upstream_source"}
+    assert _provided_by(db, "edges") == {"upstream_source"}
+
+
+def test_join_clobbers_provided_by_load_does_not(kg_with_provided_by, temp_dir):
+    """Contrast: join (generate_provided_by=True) overwrites provided_by with the
+    source filename stem; load preserves the original."""
+    nodes, edges = kg_with_provided_by
+    join_db = temp_dir / "join.duckdb"
+    join_graphs(JoinConfig(
+        node_files=[FileSpec(path=nodes, format=KGXFormat.JSONL, file_type=KGXFileType.NODES)],
+        edge_files=[FileSpec(path=edges, format=KGXFormat.JSONL, file_type=KGXFileType.EDGES)],
+        output_database=join_db, quiet=True, show_progress=False,
+    ))
+    # join stamps provided_by from the filename stem
+    assert _provided_by(join_db, "nodes") == {"mykg_nodes"}
+
+    load_db = temp_dir / "load2.duckdb"
+    load_graph(LoadConfig(
+        node_files=[FileSpec(path=nodes, format=KGXFormat.JSONL, file_type=KGXFileType.NODES)],
+        edge_files=[FileSpec(path=edges, format=KGXFormat.JSONL, file_type=KGXFileType.EDGES)],
+        output_database=load_db, quiet=True, show_progress=False,
+    ))
+    assert _provided_by(load_db, "nodes") == {"upstream_source"}
+
+
+def test_load_generate_provided_by_opt_in(kg_with_provided_by, temp_dir):
+    """Passing generate_provided_by=True restores the cat-merge stamping."""
+    nodes, edges = kg_with_provided_by
+    db = temp_dir / "stamped.duckdb"
+    load_graph(LoadConfig(
+        node_files=[FileSpec(path=nodes, format=KGXFormat.JSONL, file_type=KGXFileType.NODES)],
+        edge_files=[FileSpec(path=edges, format=KGXFormat.JSONL, file_type=KGXFileType.EDGES)],
+        output_database=db, generate_provided_by=True, quiet=True, show_progress=False,
+    ))
+    assert _provided_by(db, "nodes") == {"mykg_nodes"}
+
+
+def test_prepare_load_config_from_paths(kg_with_provided_by, temp_dir):
+    """The paths helper builds a LoadConfig (faithful defaults) and load_graph runs it."""
+    nodes, edges = kg_with_provided_by
+    db = temp_dir / "viahelper.duckdb"
+    config = prepare_load_config_from_paths(
+        node_files=[nodes], edge_files=[edges], output_database=db,
+        quiet=True, show_progress=False,
+    )
+    assert isinstance(config, LoadConfig)
+    assert config.generate_provided_by is False
+    assert config.schema_reporting is False
+    result = load_graph(config)
+    assert result.final_stats.nodes == 2
+    assert _provided_by(db, "edges") == {"upstream_source"}


### PR DESCRIPTION
## Motivation

Loading a knowledge graph that's already represented as a nodes file + an edges file currently means either:
- `koza join` — but that's **cat-merge style**: it overwrites `provided_by` with the source filename stem, and the CLI doesn't even expose a way to turn that off (`generate_provided_by` exists on `JoinConfig` but isn't wired to a flag). So you can't load an already-built KG faithfully from the CLI.
- `koza merge` — the full join → deduplicate → normalize → prune pipeline, which is far more than "get this graph into DuckDB."

Neither fits the common "I just want this graph in DuckDB as-is for analysis (or to `closurize` / `report`)" case. This adds a plain `load` verb for exactly that — the first step of a build, on its own.

## What's added

- **CLI:** `koza load -n nodes.jsonl -e edges.jsonl -o graph.duckdb` (also `--input-dir`, multiple `-n`/`-e`, globs — same input handling as `join`).
- **Python API:** `load_graph(config)` and `prepare_load_config_from_paths(...)`, mirroring `merge_graphs` / `prepare_merge_config_from_paths`.
- **`LoadConfig`** subclasses `JoinConfig` with faithful-load defaults:
  - `generate_provided_by=False` — preserve an existing `provided_by` instead of stamping it from the filename (`--generate-provided-by` opts back into the cat-merge behavior).
  - `schema_reporting=False` — no schema report by default.

  So `load_graph` is `join_graphs` with these defaults; same `nodes`/`edges` tables, same schema seeding, so `closurize`/`report` work downstream.

## Semantics

`load` and `join` share the mechanism (ingest into `nodes`/`edges`); they differ in **provenance intent**: `join`/`merge` *build* a graph from raw per-source files (stamp `provided_by` from filenames); `load` brings an *existing* graph in as-is. Documented in `CONTEXT.md`.

## Verification

- New `tests/test_load.py` (5 tests): table creation, `provided_by` preservation, the join-clobbers-vs-load-preserves contrast, the `--generate-provided-by` opt-in, and the paths helper. Full suite: **401 passed, 10 skipped**.
- Smoke-tested on a real KG (`koza load -n geneticskp_nodes.jsonl -e geneticskp_edges.jsonl`): 1,116,058 edges loaded; `provided_by` not fabricated; original `sources` provenance (`infores:geneticskp`) intact — vs `join`, which stamped `provided_by='geneticskp_edges'`.
