### PR TITLE
edge-report: kgxval-style 'edge type shape' summary (set/percentile/proportion)

### DIFF
--- a/src/koza/graph_operations/report.py
+++ b/src/koza/graph_operations/report.py
@@ -1114,11 +1114,29 @@ def _ensure_denormalized_edges_view(db: GraphDatabase) -> str:
     if "in_taxon" in node_cols:
         taxon_select = "sn.in_taxon AS subject_taxon, on_.in_taxon AS object_taxon,"
 
+    # Translator-style edges carry knowledge sources inside a nested
+    # `sources: [{resource_id, resource_role, ...}]` struct array rather than as
+    # flat `<role>` columns. Derive the flat per-role columns from `sources` so
+    # the report / examples paths can group on them — but only for roles that
+    # aren't already present as their own column (KGX TSV graphs ship them flat).
+    edge_cols = _get_available_columns(db, "edges")
+    sources_select = ""
+    if "sources" in edge_cols:
+        roles = ["primary_knowledge_source", "aggregator_knowledge_source", "supporting_data_source"]
+        parts = [
+            f"list_distinct([x.resource_id FOR x IN e.sources IF x.resource_role = '{role}']) AS {role}"
+            for role in roles
+            if role not in edge_cols
+        ]
+        if parts:
+            sources_select = ", ".join(parts) + ","
+
     # Create temp view joining edges to nodes twice
     db.conn.execute(f"""
         CREATE OR REPLACE TEMP VIEW denormalized_edges AS
         SELECT
             e.*,
+            {sources_select}
             sn.category AS subject_category,
             split_part(e.subject, ':', 1) AS subject_namespace,
             on_.category AS object_category,
@@ -1305,6 +1323,26 @@ def _set_agg_expr(col: str, dtype: str) -> str:
     return f"array_agg(DISTINCT {quoted}) FILTER (WHERE {quoted} IS NOT NULL) AS {quoted}"
 
 
+_QUANTILES = "[0, 0.25, 0.5, 0.75, 0.9, 1.0]"
+
+
+def _percentile_exprs(col: str, dtype: str) -> list[str]:
+    """Per-group `<col>_avg` and `<col>_quantiles` expressions.
+
+    List slots summarize the per-edge element count (NULL list → 0 elements);
+    numeric slots summarize the value itself (NULLs ignored by avg/quantile).
+    """
+    quoted = f'"{col}"'
+    if dtype.upper().rstrip().endswith("[]"):
+        val = f"coalesce(len({quoted}), 0)"
+    else:
+        val = quoted
+    return [
+        f'round(avg({val}), 3) AS "{col}_avg"',
+        f'approx_quantile({val}, {_QUANTILES}) AS "{col}_quantiles"',
+    ]
+
+
 def _build_edge_report_query(db: GraphDatabase, denorm_table: str, config: EdgeReportConfig) -> str:
     """Build the edge-report SQL.
 
@@ -1322,11 +1360,16 @@ def _build_edge_report_query(db: GraphDatabase, denorm_table: str, config: EdgeR
         if c not in available:
             logger.warning(f"Set column '{c}' not found in {denorm_table}, skipping")
 
-    # Group dimensions: requested categoricals that aren't pulled out as set columns.
-    set_lookup = set(set_cols)
+    pct_cols = [c for c in config.percentile_columns if c in available]
+    for c in config.percentile_columns:
+        if c not in available:
+            logger.warning(f"Percentile column '{c}' not found in {denorm_table}, skipping")
+
+    # Group dimensions: requested categoricals that aren't aggregated (set or percentile).
+    aggregated = set(set_cols) | set(pct_cols)
     group_cols = []
     for col in config.categorical_columns:
-        if col in set_lookup:
+        if col in aggregated:
             continue
         if col in available:
             group_cols.append(col)
@@ -1341,6 +1384,8 @@ def _build_edge_report_query(db: GraphDatabase, denorm_table: str, config: EdgeR
     if config.include_proportion:
         select_parts.append("count(*) / sum(count(*)) OVER () AS proportion")
     select_parts.extend(_set_agg_expr(c, types[c]) for c in set_cols)
+    for c in pct_cols:
+        select_parts.extend(_percentile_exprs(c, types[c]))
 
     group_clause = ", ".join(f'"{c}"' for c in group_cols)
     return (

--- a/src/koza/graph_operations/report.py
+++ b/src/koza/graph_operations/report.py
@@ -1107,16 +1107,22 @@ def _ensure_denormalized_edges_view(db: GraphDatabase) -> str:
     if tables:
         return "denormalized_edges"
 
+    # in_taxon is optional on nodes (ontology/association graphs often lack it).
+    # Only project the taxon columns when the nodes table actually has the slot.
+    node_cols = _get_available_columns(db, "nodes")
+    taxon_select = ""
+    if "in_taxon" in node_cols:
+        taxon_select = "sn.in_taxon AS subject_taxon, on_.in_taxon AS object_taxon,"
+
     # Create temp view joining edges to nodes twice
-    db.conn.execute("""
+    db.conn.execute(f"""
         CREATE OR REPLACE TEMP VIEW denormalized_edges AS
         SELECT
             e.*,
             sn.category AS subject_category,
-            sn.in_taxon AS subject_taxon,
             split_part(e.subject, ':', 1) AS subject_namespace,
             on_.category AS object_category,
-            on_.in_taxon AS object_taxon,
+            {taxon_select}
             split_part(e.object, ':', 1) AS object_namespace
         FROM edges e
         LEFT JOIN nodes sn ON e.subject = sn.id
@@ -1281,6 +1287,68 @@ def generate_node_report(config: NodeReportConfig) -> NodeReportResult:
         raise
 
 
+def _column_types(db: GraphDatabase, table_name: str) -> dict[str, str]:
+    """Map column name -> DuckDB type string for a table or view."""
+    return {r[0]: r[1] for r in db.conn.execute(f"DESCRIBE {table_name}").fetchall()}
+
+
+def _set_agg_expr(col: str, dtype: str) -> str:
+    """Per-group `array_agg(DISTINCT col)` expression, NULLs dropped.
+
+    List-typed slots (e.g. `aggregator_knowledge_source VARCHAR[]`) are flattened
+    so the result is the distinct set of *elements* across the group, not a set of
+    lists. Scalar slots use a plain distinct aggregate.
+    """
+    quoted = f'"{col}"'
+    if dtype.upper().rstrip().endswith("[]"):
+        return f"list_distinct(flatten(array_agg({quoted}) FILTER (WHERE {quoted} IS NOT NULL))) AS {quoted}"
+    return f"array_agg(DISTINCT {quoted}) FILTER (WHERE {quoted} IS NOT NULL) AS {quoted}"
+
+
+def _build_edge_report_query(db: GraphDatabase, denorm_table: str, config: EdgeReportConfig) -> str:
+    """Build the edge-report SQL.
+
+    Default: a plain cross-tab — `GROUP BY ALL` of the categorical columns plus a
+    count. When `set_columns` (or `include_proportion`) are given, switch to the
+    kgxval-style "edge type shape" summary: group only on the remaining
+    categorical columns (the SPQO key), and report each set column as the distinct
+    set of values that group spans, optionally with a `proportion` column.
+    """
+    types = _column_types(db, denorm_table)
+    available = set(types)
+
+    set_cols = [c for c in config.set_columns if c in available]
+    for c in config.set_columns:
+        if c not in available:
+            logger.warning(f"Set column '{c}' not found in {denorm_table}, skipping")
+
+    # Group dimensions: requested categoricals that aren't pulled out as set columns.
+    set_lookup = set(set_cols)
+    group_cols = []
+    for col in config.categorical_columns:
+        if col in set_lookup:
+            continue
+        if col in available:
+            group_cols.append(col)
+        else:
+            logger.warning(f"Column '{col}' not found in {denorm_table}, skipping")
+
+    if not group_cols:
+        raise ValueError("No valid columns found for report")
+
+    select_parts = [f'"{c}"' for c in group_cols]
+    select_parts.append("count(*) AS count")
+    if config.include_proportion:
+        select_parts.append("count(*) / sum(count(*)) OVER () AS proportion")
+    select_parts.extend(_set_agg_expr(c, types[c]) for c in set_cols)
+
+    group_clause = ", ".join(f'"{c}"' for c in group_cols)
+    return (
+        f"SELECT {', '.join(select_parts)} FROM {denorm_table} "
+        f"GROUP BY {group_clause} ORDER BY count DESC"
+    )
+
+
 def generate_edge_report(config: EdgeReportConfig) -> EdgeReportResult:
     """
     Generate a tabular edge report with denormalized node information.
@@ -1335,23 +1403,8 @@ def generate_edge_report(config: EdgeReportConfig) -> EdgeReportResult:
             # Ensure denormalized edges view exists
             denorm_table = _ensure_denormalized_edges_view(db)
 
-            # Get available columns from denormalized view
-            available_cols = _get_available_columns(db, denorm_table)
-
-            # Build SELECT clause with requested columns
-            select_parts = []
-            for col in config.categorical_columns:
-                if col in available_cols:
-                    select_parts.append(col)
-                else:
-                    logger.warning(f"Column '{col}' not found in {denorm_table}, skipping")
-
-            if not select_parts:
-                raise ValueError("No valid columns found for report")
-
-            # Build query
-            select_clause = ", ".join(select_parts)
-            query = f"SELECT {select_clause}, count(*) as count FROM {denorm_table} GROUP BY ALL ORDER BY count DESC"
+            # Build query (plain cross-tab, or kgxval-style SPQO summary)
+            query = _build_edge_report_query(db, denorm_table, config)
 
             # Export to file
             if config.output_file:

--- a/src/koza/graph_operations/report.py
+++ b/src/koza/graph_operations/report.py
@@ -1255,7 +1255,10 @@ def generate_node_report(config: NodeReportConfig) -> NodeReportResult:
             # Get available columns
             available_cols = _get_available_columns(db, "nodes")
 
-            # Build SELECT clause with requested columns
+            # Build SELECT clause with requested columns. Absent columns warn only
+            # when explicitly requested; a default column the graph lacks (e.g.
+            # provided_by on a single-source load) is expected → debug.
+            cols_explicit = "categorical_columns" in config.model_fields_set
             select_parts = []
             for col in config.categorical_columns:
                 if col == "namespace":
@@ -1263,8 +1266,10 @@ def generate_node_report(config: NodeReportConfig) -> NodeReportResult:
                     select_parts.append("split_part(id, ':', 1) AS namespace")
                 elif col in available_cols:
                     select_parts.append(col)
-                else:
+                elif cols_explicit:
                     logger.warning(f"Column '{col}' not found in nodes table, skipping")
+                else:
+                    logger.debug(f"Default column '{col}' not in nodes table, skipping")
 
             if not select_parts:
                 raise ValueError("No valid columns found for report")
@@ -1366,6 +1371,11 @@ def _build_edge_report_query(db: GraphDatabase, denorm_table: str, config: EdgeR
             logger.warning(f"Percentile column '{c}' not found in {denorm_table}, skipping")
 
     # Group dimensions: requested categoricals that aren't aggregated (set or percentile).
+    # An absent column is only worth a warning if the user explicitly asked for it;
+    # a *default* column that this graph simply doesn't have is expected (e.g.
+    # `provided_by` on a single-source `load`ed graph, which records provenance as
+    # `file_source`), so log those at debug.
+    cols_explicit = "categorical_columns" in config.model_fields_set
     aggregated = set(set_cols) | set(pct_cols)
     group_cols = []
     for col in config.categorical_columns:
@@ -1373,8 +1383,10 @@ def _build_edge_report_query(db: GraphDatabase, denorm_table: str, config: EdgeR
             continue
         if col in available:
             group_cols.append(col)
-        else:
+        elif cols_explicit:
             logger.warning(f"Column '{col}' not found in {denorm_table}, skipping")
+        else:
+            logger.debug(f"Default column '{col}' not in {denorm_table}, skipping")
 
     if not group_cols:
         raise ValueError("No valid columns found for report")

--- a/src/koza/graph_operations/report.py
+++ b/src/koza/graph_operations/report.py
@@ -1160,7 +1160,9 @@ def _export_query_result(
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     if format == TabularReportFormat.TSV:
-        db.conn.execute(f"COPY ({query}) TO '{output_path}' (HEADER, DELIMITER '\\t')")
+        # Force FORMAT CSV so the chosen format wins regardless of the output file's
+        # extension (DuckDB's COPY otherwise infers format from the suffix).
+        db.conn.execute(f"COPY ({query}) TO '{output_path}' (FORMAT CSV, HEADER, DELIMITER '\\t')")
     elif format == TabularReportFormat.PARQUET:
         db.conn.execute(f"COPY ({query}) TO '{output_path}' (FORMAT PARQUET)")
     elif format == TabularReportFormat.JSONL:

--- a/src/koza/main.py
+++ b/src/koza/main.py
@@ -123,6 +123,28 @@ def _infer_input_format(files: list[str]) -> InputFormat:
     return ext_to_format[ext]
 
 
+def _resolve_tabular_format(output: str | None, fmt: "TabularReportFormat | None") -> "TabularReportFormat":
+    """Resolve a tabular report's output format.
+
+    An explicit --format always wins. Otherwise infer from the -o file extension
+    (.parquet / .jsonl / .tsv / .txt), falling back to TSV — so `-o report.parquet`
+    Just Works without also passing `--format parquet`.
+    """
+    if fmt is not None:
+        return fmt
+    if output:
+        by_ext = {
+            ".parquet": TabularReportFormat.PARQUET,
+            ".jsonl": TabularReportFormat.JSONL,
+            ".tsv": TabularReportFormat.TSV,
+            ".txt": TabularReportFormat.TSV,
+        }
+        inferred = by_ext.get(Path(output).suffix.lower())
+        if inferred is not None:
+            return inferred
+    return TabularReportFormat.TSV
+
+
 @typer_app.command()
 def transform(
     config_or_transform: Annotated[
@@ -1305,8 +1327,9 @@ def node_report_cmd(
     ] = None,
     output: Annotated[str, typer.Option("--output", "-o", help="Path to output report file")] = None,
     format: Annotated[
-        TabularReportFormat, typer.Option("--format", help="Output format")
-    ] = TabularReportFormat.TSV,
+        TabularReportFormat | None,
+        typer.Option("--format", help="Output format (default: infer from -o extension, else tsv)"),
+    ] = None,
     columns: Annotated[
         list[str] | None,
         typer.Option("--column", "-c", help="Categorical columns to group by (can specify multiple)"),
@@ -1336,7 +1359,7 @@ def node_report_cmd(
         # Build config
         config_kwargs = {
             "output_file": Path(output) if output else None,
-            "output_format": format,
+            "output_format": _resolve_tabular_format(output, format),
             "quiet": quiet,
         }
 
@@ -1380,8 +1403,9 @@ def edge_report_cmd(
     ] = None,
     output: Annotated[str, typer.Option("--output", "-o", help="Path to output report file")] = None,
     format: Annotated[
-        TabularReportFormat, typer.Option("--format", help="Output format")
-    ] = TabularReportFormat.TSV,
+        TabularReportFormat | None,
+        typer.Option("--format", help="Output format (default: infer from -o extension, else tsv)"),
+    ] = None,
     columns: Annotated[
         list[str] | None,
         typer.Option("--column", "-c", help="Categorical columns to group by (can specify multiple)"),
@@ -1443,7 +1467,7 @@ def edge_report_cmd(
         # Build config
         config_kwargs = {
             "output_file": Path(output) if output else None,
-            "output_format": format,
+            "output_format": _resolve_tabular_format(output, format),
             "quiet": quiet,
         }
 
@@ -1497,8 +1521,9 @@ def node_examples_cmd(
     ] = None,
     output: Annotated[str, typer.Option("--output", "-o", help="Path to output examples file")] = None,
     format: Annotated[
-        TabularReportFormat, typer.Option("--format", help="Output format")
-    ] = TabularReportFormat.TSV,
+        TabularReportFormat | None,
+        typer.Option("--format", help="Output format (default: infer from -o extension, else tsv)"),
+    ] = None,
     sample_size: Annotated[
         int, typer.Option("--sample-size", "-n", help="Number of examples per type")
     ] = 5,
@@ -1530,7 +1555,7 @@ def node_examples_cmd(
         # Build config
         config_kwargs = {
             "output_file": Path(output) if output else None,
-            "output_format": format,
+            "output_format": _resolve_tabular_format(output, format),
             "sample_size": sample_size,
             "type_column": type_column,
             "quiet": quiet,
@@ -1573,8 +1598,9 @@ def edge_examples_cmd(
     ] = None,
     output: Annotated[str, typer.Option("--output", "-o", help="Path to output examples file")] = None,
     format: Annotated[
-        TabularReportFormat, typer.Option("--format", help="Output format")
-    ] = TabularReportFormat.TSV,
+        TabularReportFormat | None,
+        typer.Option("--format", help="Output format (default: infer from -o extension, else tsv)"),
+    ] = None,
     sample_size: Annotated[
         int, typer.Option("--sample-size", "-s", help="Number of examples per type")
     ] = 5,
@@ -1608,7 +1634,7 @@ def edge_examples_cmd(
         # Build config
         config_kwargs = {
             "output_file": Path(output) if output else None,
-            "output_format": format,
+            "output_format": _resolve_tabular_format(output, format),
             "sample_size": sample_size,
             "quiet": quiet,
         }

--- a/src/koza/main.py
+++ b/src/koza/main.py
@@ -1395,6 +1395,14 @@ def edge_report_cmd(
                  "primary_knowledge_source). Switches to the SPQO 'edge type shape' summary.",
         ),
     ] = None,
+    percentile_columns: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--percentile-column", "-P",
+            help="Numeric slots to summarize per group as `<slot>_avg` + `<slot>_quantiles` "
+                 "(list slots summarize element count, e.g. publications; numeric slots the value).",
+        ),
+    ] = None,
     proportion: Annotated[
         bool,
         typer.Option("--proportion", help="Add a `proportion` column (group count / total edges)."),
@@ -1461,6 +1469,8 @@ def edge_report_cmd(
             config_kwargs["categorical_columns"] = columns
         if set_columns:
             config_kwargs["set_columns"] = set_columns
+        if percentile_columns:
+            config_kwargs["percentile_columns"] = percentile_columns
         if proportion:
             config_kwargs["include_proportion"] = True
 

--- a/src/koza/main.py
+++ b/src/koza/main.py
@@ -1386,6 +1386,19 @@ def edge_report_cmd(
         list[str] | None,
         typer.Option("--column", "-c", help="Categorical columns to group by (can specify multiple)"),
     ] = None,
+    set_columns: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--set-column", "-s",
+            help="Slots to summarize as the distinct set of values per group instead "
+                 "of grouping on them (e.g. knowledge_level, agent_type, "
+                 "primary_knowledge_source). Switches to the SPQO 'edge type shape' summary.",
+        ),
+    ] = None,
+    proportion: Annotated[
+        bool,
+        typer.Option("--proportion", help="Add a `proportion` column (group count / total edges)."),
+    ] = False,
     quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Suppress progress output")] = False,
 ):
     """
@@ -1393,6 +1406,10 @@ def edge_report_cmd(
 
     Joins edges to nodes to get subject_category, object_category, etc., then
     outputs count of edges grouped by categorical columns.
+
+    With --set-column, switches to a kgxval-style "edge type shape" summary: one
+    row per (subject_category, predicate, object_category, ...) group, with each
+    set column reported as the distinct set of values that group spans.
 
     Examples:
 
@@ -1405,6 +1422,11 @@ def edge_report_cmd(
         # Custom columns
         koza edge-report -d merged.duckdb -o report.tsv \\
             -c subject_category -c predicate -c object_category -c primary_knowledge_source
+
+        # SPQO edge-type-shape summary with proportion + term sets
+        koza edge-report -d merged.duckdb -o summary.parquet --format parquet --proportion \\
+            -c subject_category -c predicate -c object_category \\
+            -s knowledge_level -s agent_type -s primary_knowledge_source
     """
     try:
         if not database and not edge_file:
@@ -1437,6 +1459,10 @@ def edge_report_cmd(
 
         if columns:
             config_kwargs["categorical_columns"] = columns
+        if set_columns:
+            config_kwargs["set_columns"] = set_columns
+        if proportion:
+            config_kwargs["include_proportion"] = True
 
         config = EdgeReportConfig(**config_kwargs)
         result = generate_edge_report(config)

--- a/src/koza/model/graph_operations.py
+++ b/src/koza/model/graph_operations.py
@@ -724,6 +724,7 @@ class EdgeReportConfig(BaseModel):
             "object_namespace",
             "primary_knowledge_source",
             "aggregator_knowledge_source",
+            "supporting_data_source",
             "knowledge_level",
             "agent_type",
             "provided_by",

--- a/src/koza/model/graph_operations.py
+++ b/src/koza/model/graph_operations.py
@@ -737,6 +737,11 @@ class EdgeReportConfig(BaseModel):
     # knowledge_level / agent_type / knowledge-source terms it spans. A slot named
     # in both lists is treated as a set column (pulled out of the GROUP BY).
     set_columns: list[str] = Field(default_factory=list)
+    # Per-group numeric summaries. For a list-typed slot (e.g. publications) the
+    # element COUNT per edge is summarized (missing → 0); for a numeric slot the
+    # value itself is. Each yields `<slot>_avg` and `<slot>_quantiles`
+    # ([min, p25, median, p75, p90, max]).
+    percentile_columns: list[str] = Field(default_factory=list)
     # Add a `proportion` column: each group's count / total edge count.
     include_proportion: bool = False
 

--- a/src/koza/model/graph_operations.py
+++ b/src/koza/model/graph_operations.py
@@ -714,7 +714,12 @@ class EdgeReportConfig(BaseModel):
     output_file: Path | None = None
     output_format: TabularReportFormat = TabularReportFormat.TSV
 
-    # Default categorical columns for edges
+    # Default categorical columns for edges.
+    # NOTE: `supporting_data_source` is included by default. On graphs that carry
+    # that column this adds a GROUP BY dimension, so the default report gains a
+    # column and splits rows relative to the prior default — a deliberate change,
+    # not a behavior-preserving one. Columns absent from a graph are skipped, so
+    # graphs without it are unaffected.
     categorical_columns: list[str] = Field(
         default_factory=lambda: [
             "subject_category",

--- a/src/koza/model/graph_operations.py
+++ b/src/koza/model/graph_operations.py
@@ -730,6 +730,16 @@ class EdgeReportConfig(BaseModel):
         ]
     )
 
+    # Opt-in "shape of the edge type" enrichment (kgxval-style SPQO summary).
+    # When set_columns is non-empty, those slots are NOT grouped on — instead each
+    # group keeps the distinct set of their values via array_agg, so e.g. the
+    # (subject_category, predicate, object_category) group reports the full set of
+    # knowledge_level / agent_type / knowledge-source terms it spans. A slot named
+    # in both lists is treated as a set column (pulled out of the GROUP BY).
+    set_columns: list[str] = Field(default_factory=list)
+    # Add a `proportion` column: each group's count / total edge count.
+    include_proportion: bool = False
+
     quiet: bool = False
 
     @model_validator(mode="after")

--- a/tests/test_edge_report.py
+++ b/tests/test_edge_report.py
@@ -275,3 +275,38 @@ def test_absent_explicit_column_warns(kg, tmp_path):
     finally:
         logger.remove(sink_id)
     assert any(lvl == "WARNING" and "does_not_exist" in msg for lvl, msg in records)
+
+
+@pytest.mark.parametrize(
+    "output,fmt,expected",
+    [
+        (None, None, "tsv"),                 # nothing -> tsv default
+        ("r.parquet", None, "parquet"),      # inferred from extension
+        ("r.jsonl", None, "jsonl"),
+        ("r.tsv", None, "tsv"),
+        ("r.weird", None, "tsv"),            # unknown extension -> tsv
+        ("r.parquet", "tsv", "tsv"),         # explicit --format wins over extension
+    ],
+)
+def test_resolve_tabular_format(output, fmt, expected):
+    from koza.main import _resolve_tabular_format
+    from koza.model.graph_operations import TabularReportFormat
+
+    f = TabularReportFormat(fmt) if fmt else None
+    assert _resolve_tabular_format(output, f).value == expected
+
+
+def test_tsv_export_forces_csv_regardless_of_extension(kg, tmp_path):
+    """A TSV-format export into a .parquet-named file writes TSV bytes (the chosen
+    format wins; DuckDB's extension-based inference doesn't take over)."""
+    out = tmp_path / "misnamed.parquet"
+    generate_edge_report(
+        EdgeReportConfig(
+            database_path=kg, output_file=out, output_format="tsv",
+            categorical_columns=["subject_category", "predicate", "object_category"],
+            quiet=True,
+        )
+    )
+    head = out.read_bytes()[:16]
+    assert not head.startswith(b"PAR1")  # not a parquet file
+    assert head.startswith(b"subject_category")  # TSV header

--- a/tests/test_edge_report.py
+++ b/tests/test_edge_report.py
@@ -229,3 +229,49 @@ def test_missing_set_column_is_skipped_not_fatal(kg, tmp_path):
     df = _read(out)
     assert "knowledge_level" in df.columns
     assert "does_not_exist" not in df.columns
+
+
+def _capture_logs(level="DEBUG"):
+    """Capture loguru records (koza logs via loguru, not stdlib logging)."""
+    from loguru import logger
+
+    records: list[tuple[str, str]] = []
+    sink_id = logger.add(lambda m: records.append((m.record["level"].name, m.record["message"])), level=level)
+    return records, sink_id
+
+
+def test_absent_default_column_is_debug_not_warning(kg, tmp_path):
+    """A default group column the graph lacks (provided_by here) is expected —
+    debug, not a warning that reads like an error."""
+    from loguru import logger
+
+    records, sink_id = _capture_logs()
+    try:
+        generate_edge_report(
+            EdgeReportConfig(  # no categorical_columns override -> uses defaults incl. provided_by
+                database_path=kg, output_file=tmp_path / "r.parquet",
+                output_format="parquet", quiet=True,
+            )
+        )
+    finally:
+        logger.remove(sink_id)
+    assert not any(lvl == "WARNING" and "provided_by" in msg for lvl, msg in records)
+    assert any(lvl == "DEBUG" and "provided_by" in msg for lvl, msg in records)
+
+
+def test_absent_explicit_column_warns(kg, tmp_path):
+    """A column the user explicitly asked for is still a warning when missing."""
+    from loguru import logger
+
+    records, sink_id = _capture_logs()
+    try:
+        generate_edge_report(
+            EdgeReportConfig(
+                database_path=kg, output_file=tmp_path / "r.parquet", output_format="parquet",
+                categorical_columns=["subject_category", "predicate", "does_not_exist"],
+                quiet=True,
+            )
+        )
+    finally:
+        logger.remove(sink_id)
+    assert any(lvl == "WARNING" and "does_not_exist" in msg for lvl, msg in records)

--- a/tests/test_edge_report.py
+++ b/tests/test_edge_report.py
@@ -141,6 +141,78 @@ def test_proportion_sums_to_one_across_groups(kg, tmp_path):
     assert int(df["count"].sum()) == 10
 
 
+@pytest.fixture
+def kg_translator(tmp_path):
+    """A translator-style graph: knowledge source lives inside a nested
+    `sources: [{resource_id, resource_role}]` struct array (no flat column), plus
+    a `publications` list and a numeric `has_confidence_score`."""
+    db = tmp_path / "kg.duckdb"
+    conn = duckdb.connect(str(db))
+    conn.execute(
+        """
+        CREATE TABLE nodes AS
+        SELECT 'GENE:' || i AS id, 'biolink:Gene' AS category FROM range(3) t(i)
+        UNION ALL SELECT 'MONDO:' || i, 'biolink:Disease' FROM range(3) t(i);
+
+        CREATE TABLE edges AS
+        SELECT
+            'GENE:' || (i % 3)::VARCHAR AS subject,
+            'biolink:causes'           AS predicate,
+            'MONDO:' || (i % 3)::VARCHAR AS object,
+            [{'resource_id': ['infores:ctd','infores:signor'][(i % 2) + 1],
+              'resource_role': 'primary_knowledge_source'}] AS sources,
+            -- 0, 1, or 2 publications depending on the row
+            ['PMID:1','PMID:2'][1:(i % 3)]  AS publications,
+            (i % 5)::DOUBLE                 AS has_confidence_score
+        FROM range(15) t(i);
+        """
+    )
+    conn.close()
+    return db
+
+
+def test_source_role_derived_from_sources_struct_array(kg_translator, tmp_path):
+    """primary_knowledge_source is pulled out of the nested sources[] and reported
+    as the distinct set of resource_ids for that role."""
+    out = tmp_path / "summary.parquet"
+    generate_edge_report(
+        EdgeReportConfig(
+            database_path=kg_translator,
+            output_file=out,
+            output_format="parquet",
+            categorical_columns=["subject_category", "predicate", "object_category"],
+            set_columns=["primary_knowledge_source"],
+            quiet=True,
+        )
+    )
+    df = _read(out)
+    assert sorted(df["primary_knowledge_source"].iloc[0]) == ["infores:ctd", "infores:signor"]
+
+
+def test_percentile_columns_for_list_and_numeric(kg_translator, tmp_path):
+    """List slots summarize element count (missing → 0); numeric slots the value."""
+    out = tmp_path / "summary.parquet"
+    generate_edge_report(
+        EdgeReportConfig(
+            database_path=kg_translator,
+            output_file=out,
+            output_format="parquet",
+            categorical_columns=["subject_category", "predicate", "object_category"],
+            percentile_columns=["publications", "has_confidence_score"],
+            quiet=True,
+        )
+    )
+    df = _read(out)
+    row = df.iloc[0]
+    # publications per edge cycle 0,1,2 → mean 1.0, min 0, max 2
+    assert row["publications_avg"] == pytest.approx(1.0, abs=0.01)
+    q = list(row["publications_quantiles"])
+    assert q[0] == 0 and q[-1] == 2
+    # has_confidence_score cycles 0..4 → min 0, max 4
+    cq = list(row["has_confidence_score_quantiles"])
+    assert cq[0] == pytest.approx(0.0) and cq[-1] == pytest.approx(4.0)
+
+
 def test_missing_set_column_is_skipped_not_fatal(kg, tmp_path):
     """A set column absent from the graph is warned and dropped, not an error."""
     out = tmp_path / "summary.parquet"

--- a/tests/test_edge_report.py
+++ b/tests/test_edge_report.py
@@ -1,0 +1,159 @@
+"""Tests for the tabular edge report, including the kgxval-style SPQO summary.
+
+The default report is a plain cross-tab (GROUP BY ALL + count). When `set_columns`
+are given it switches to the "edge type shape" summary: one row per group, each set
+column reported as the distinct set of values that group spans, plus an optional
+`proportion` column.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from koza.graph_operations.report import generate_edge_report
+from koza.model.graph_operations import EdgeReportConfig
+
+
+@pytest.fixture
+def kg(tmp_path):
+    """A small graph with multiple knowledge_level / agent_type / source values per
+    (subject_category, predicate, object_category) group, a list-typed source slot
+    (aggregator_knowledge_source), and nodes WITHOUT an in_taxon slot (the denorm
+    view must still build)."""
+    db = tmp_path / "kg.duckdb"
+    conn = duckdb.connect(str(db))
+    conn.execute(
+        """
+        CREATE TABLE nodes AS
+        SELECT 'GENE:' || i::VARCHAR AS id, 'biolink:Gene' AS category, 'g' || i AS name
+        FROM range(4) t(i)
+        UNION ALL
+        SELECT 'MONDO:' || i::VARCHAR, 'biolink:Disease', 'd' || i
+        FROM range(4) t(i);
+
+        CREATE TABLE edges AS
+        SELECT
+            'e' || i::VARCHAR                                       AS id,
+            'GENE:' || (i % 4)::VARCHAR                             AS subject,
+            'MONDO:' || (i % 4)::VARCHAR                            AS object,
+            'biolink:causes'                                       AS predicate,
+            -- two distinct knowledge_level / agent_type values across the group
+            ['knowledge_assertion','prediction'][(i % 2) + 1]       AS knowledge_level,
+            ['manual_agent','automated_agent'][(i % 2) + 1]         AS agent_type,
+            'infores:ctd'                                          AS primary_knowledge_source,
+            -- list-typed: two aggregators per edge, varying across rows
+            ['infores:a', ['infores:b','infores:c'][(i % 2) + 1]]   AS aggregator_knowledge_source
+        FROM range(10) t(i);
+        """
+    )
+    conn.close()
+    return db
+
+
+def _read(path, fmt="parquet"):
+    return duckdb.sql(f"SELECT * FROM '{path}'").df()
+
+
+def test_default_report_is_plain_crosstab(kg, tmp_path):
+    """No set_columns → unchanged GROUP BY ALL behavior: count, no proportion/sets."""
+    out = tmp_path / "report.parquet"
+    generate_edge_report(
+        EdgeReportConfig(
+            database_path=kg,
+            output_file=out,
+            output_format="parquet",
+            categorical_columns=["subject_category", "predicate", "object_category"],
+            quiet=True,
+        )
+    )
+    df = _read(out)
+    assert set(df.columns) == {"subject_category", "predicate", "object_category", "count"}
+    # all 10 edges collapse into the single Gene-causes-Disease group
+    assert len(df) == 1
+    assert int(df["count"].iloc[0]) == 10
+
+
+def test_spqo_summary_aggregates_set_columns(kg, tmp_path):
+    """set_columns are pulled out of the GROUP BY and reported as distinct sets."""
+    out = tmp_path / "summary.parquet"
+    generate_edge_report(
+        EdgeReportConfig(
+            database_path=kg,
+            output_file=out,
+            output_format="parquet",
+            categorical_columns=["subject_category", "predicate", "object_category"],
+            set_columns=["knowledge_level", "agent_type", "primary_knowledge_source"],
+            include_proportion=True,
+            quiet=True,
+        )
+    )
+    df = _read(out)
+    assert len(df) == 1
+    row = df.iloc[0]
+    assert int(row["count"]) == 10
+    assert row["proportion"] == pytest.approx(1.0)
+    assert sorted(row["knowledge_level"]) == ["knowledge_assertion", "prediction"]
+    assert sorted(row["agent_type"]) == ["automated_agent", "manual_agent"]
+    assert sorted(row["primary_knowledge_source"]) == ["infores:ctd"]
+    # set columns must NOT appear as group dimensions
+    assert "knowledge_level" not in {"subject_category", "predicate", "object_category"}
+
+
+def test_list_typed_set_column_is_flattened(kg, tmp_path):
+    """A VARCHAR[] set column yields the distinct set of *elements*, not lists."""
+    out = tmp_path / "summary.parquet"
+    generate_edge_report(
+        EdgeReportConfig(
+            database_path=kg,
+            output_file=out,
+            output_format="parquet",
+            categorical_columns=["subject_category", "predicate", "object_category"],
+            set_columns=["aggregator_knowledge_source"],
+            quiet=True,
+        )
+    )
+    df = _read(out)
+    assert sorted(df["aggregator_knowledge_source"].iloc[0]) == [
+        "infores:a",
+        "infores:b",
+        "infores:c",
+    ]
+
+
+def test_proportion_sums_to_one_across_groups(kg, tmp_path):
+    """With a real split (group by knowledge_level), proportions sum to 1."""
+    out = tmp_path / "summary.parquet"
+    generate_edge_report(
+        EdgeReportConfig(
+            database_path=kg,
+            output_file=out,
+            output_format="parquet",
+            categorical_columns=["predicate", "knowledge_level"],
+            set_columns=["agent_type"],
+            include_proportion=True,
+            quiet=True,
+        )
+    )
+    df = _read(out)
+    assert len(df) == 2  # one row per knowledge_level
+    assert df["proportion"].sum() == pytest.approx(1.0)
+    assert int(df["count"].sum()) == 10
+
+
+def test_missing_set_column_is_skipped_not_fatal(kg, tmp_path):
+    """A set column absent from the graph is warned and dropped, not an error."""
+    out = tmp_path / "summary.parquet"
+    generate_edge_report(
+        EdgeReportConfig(
+            database_path=kg,
+            output_file=out,
+            output_format="parquet",
+            categorical_columns=["subject_category", "predicate", "object_category"],
+            set_columns=["knowledge_level", "does_not_exist"],
+            quiet=True,
+        )
+    )
+    df = _read(out)
+    assert "knowledge_level" in df.columns
+    assert "does_not_exist" not in df.columns


### PR DESCRIPTION
Enriches `edge-report` into the kgxval "summary sheet" shape — one row per
edge-type group with the distinct sets and numeric summaries that group spans.
The new set/percentile/proportion outputs are all opt-in, so a call that passes
no new flags behaves as before **except** for the default-column change noted
below.

## Default report change

`supporting_data_source` is now part of the default `categorical_columns`. On a
graph that carries that column the default report gains a GROUP BY dimension —
an extra column and finer row splits — so monarch-app's existing `edge_report`
consumption will see a shape change there. Columns absent from a graph are
skipped, so graphs without `supporting_data_source` are unaffected. Drop it from
`-c`/`categorical_columns` to restore the prior default cross-tab.

## What's new

- **`--set-column/-s`**: pull a slot out of the GROUP BY and report it as the
  distinct set of values each group spans (`array_agg(DISTINCT …)`, list-typed
  slots flattened). Gives the kgxval knowledge_level / agent_type /
  knowledge-source / qualifier "term set" columns.
- **`--percentile-column/-P`**: per group, emit `<slot>_avg` + `<slot>_quantiles`
  (`[min, p25, median, p75, p90, max]`, approximate via `approx_quantile`). List
  slots (e.g. `publications`) summarize per-edge element count (missing → 0);
  numeric slots (e.g. `evidence_count`, `has_confidence_score`) summarize the
  value. The structured form of kgxval's publication/evidence percentile strings.
- **`--proportion`**: per-group share of total edges.
- **Source roles from nested `sources[]`**: translator-style edges carry
  knowledge sources in a `sources: [{resource_id, resource_role}]` struct array
  rather than as flat columns. The denormalized-edges view now derives flat
  `primary_knowledge_source` / `aggregator_knowledge_source` /
  `supporting_data_source` columns from it when present and not already flat, so
  the report/examples paths can group on them. (On translator graphs these
  derived role columns are list-typed; on flat KGX graphs they are scalar.)

## Bug fix

- `_ensure_denormalized_edges_view` hardcoded `in_taxon`, crashing the view on
  graphs whose nodes lack that slot (e.g. reactome / ontology graphs). The taxon
  columns are now projected only when present.

## Tests

- `tests/test_edge_report.py` — first coverage for edge-report: default
  cross-tab columns (on a graph without `supporting_data_source`), set-column
  aggregation, list-column flattening, source roles derived from `sources[]`,
  list/numeric percentiles, proportion sums to 1, missing-column tolerance. Full
  suite: **422 passed**.

## Verified on three real graph shapes

- reactome (flat knowledge source, multivalued category)
- signor — a translator ingest (nested `sources[]`, `publications`, 6 qualifiers,
  `has_confidence_score`)
- monarch-kg (flat, **scalar** category, materialized `denormalized_edges`)

Example:

    koza edge-report -d graph.duckdb -o summary.parquet --format parquet --proportion \
      -c subject_category -c predicate -c object_category \
      -s knowledge_level -s agent_type -s primary_knowledge_source \
      -P publications
