### PR TITLE
Single-pass load on the explicit-columns path (enables stream/FIFO loads)

### DIFF
--- a/src/koza/graph_operations/utils.py
+++ b/src/koza/graph_operations/utils.py
@@ -69,31 +69,62 @@ def _generate_multivalued_select(
     return ", ".join(select_parts)
 
 
+def _injected_columns(generate_provided_by: bool) -> set[str]:
+    """The columns the loader injects (`file_source`, optionally `provided_by`).
+
+    These must be stripped from the input if it already supplies them, or
+    DuckDB's UNION ALL BY NAME auto-renames the duplicates (file_source_1 etc).
+    """
+    injected = {"file_source"}
+    if generate_provided_by:
+        injected.add("provided_by")
+    return injected
+
+
+def _format_exclude(present: set[str], file_path: Path | None = None) -> str:
+    """Render the EXCLUDE clause for whichever injected columns are present."""
+    if not present:
+        return ""
+    for col in sorted(present):
+        logger.debug(f"Excluding existing {col!r} column from {file_path}")
+    return f" EXCLUDE ({', '.join(sorted(present))})"
+
+
+def _injected_exclude_from_slots(slots: list[str], generate_provided_by: bool) -> str:
+    """EXCLUDE clause derived from an explicit slot list — without reading the file.
+
+    With an explicit `read_json(columns=...)` the read's schema *is* the slot
+    list, so the injected-column collisions can be computed from the slots alone.
+    Skipping the DESCRIBE probe this way means `load_file` touches the input
+    exactly once on the explicit-schema path — which is what lets it read a
+    non-seekable stream (a FIFO fed by `tar -xO …`), so a compressed release can
+    be loaded without first extracting its multi-GB JSONL to disk.
+    """
+    present = set(slots) & _injected_columns(generate_provided_by)
+    return _format_exclude(present)
+
+
 def _build_injected_columns_exclude(
     conn: duckdb.DuckDBPyConnection,
     read_stmt: str,
     file_path: Path,
     generate_provided_by: bool,
 ) -> str:
-    """Return a DuckDB EXCLUDE clause stripping any columns the loader is
-    about to inject (`file_source`, optionally `provided_by`). Without this
-    UNION ALL BY NAME ends up with auto-renamed duplicates (file_source_1
-    etc.) when an upstream ingest already supplies the column.
+    """EXCLUDE clause for an inferred-schema read: DESCRIBE the input to find
+    which injected columns it already supplies.
+
+    This reads the file. When an explicit slot list is known, use
+    `_injected_exclude_from_slots` instead — it computes the same result without
+    the extra read.
     """
-    injected = {"file_source"}
-    if generate_provided_by:
-        injected.add("provided_by")
+    injected = _injected_columns(generate_provided_by)
     try:
         schema_result = conn.execute(f"DESCRIBE SELECT * FROM {read_stmt}").fetchall()
         present = {row[0] for row in schema_result} & injected
     except Exception as e:
         logger.debug(f"Could not detect schema for {file_path}: {e}")
         return ""
-    if not present:
-        return ""
-    for col in sorted(present):
-        logger.debug(f"Excluding existing {col!r} column from {file_path}")
-    return f" EXCLUDE ({', '.join(sorted(present))})"
+    return _format_exclude(present, file_path)
 
 
 _SLOT_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
@@ -257,10 +288,16 @@ class GraphDatabase:
 
             # Strip any pre-existing file_source / provided_by from the input
             # so our injected versions don't collide (DuckDB UNION ALL BY NAME
-            # would otherwise auto-rename to file_source_1 etc).
-            exclude_clause = _build_injected_columns_exclude(
-                self.conn, read_stmt, file_spec.path, generate_provided_by
-            )
+            # would otherwise auto-rename to file_source_1 etc). With an explicit
+            # slot list we know the read schema already, so derive the exclude
+            # from the slots instead of DESCRIBE-ing the file — keeping the
+            # explicit-schema path to a single read (FIFO/stream-safe).
+            if file_spec.slots:
+                exclude_clause = _injected_exclude_from_slots(file_spec.slots, generate_provided_by)
+            else:
+                exclude_clause = _build_injected_columns_exclude(
+                    self.conn, read_stmt, file_spec.path, generate_provided_by
+                )
 
             # Load into temp table with source tracking and optional provided_by
             extra_cols_str = ", " + ", ".join(extra_columns) if extra_columns else ""

--- a/src/koza/graph_operations/utils.py
+++ b/src/koza/graph_operations/utils.py
@@ -275,6 +275,15 @@ class GraphDatabase:
 
             read_stmt = get_duckdb_read_statement(file_spec)
 
+            # The single-read "explicit columns" optimisations below are only
+            # valid when the read schema is guaranteed to equal file_spec.slots.
+            # That holds for JSONL, where get_duckdb_read_statement emits
+            # read_json(columns={...}) keyed by the slots; for TSV/Parquet the
+            # slots are ignored and the read returns the file's real columns, so
+            # we must fall back to DESCRIBE-based handling (which is seekable and
+            # therefore safe for those formats).
+            explicit_columns = bool(file_spec.slots) and file_spec.format == KGXFormat.JSONL
+
             # Create unique temp table name for this file
             safe_filename = file_spec.path.stem.replace("-", "_").replace(".", "_")
             temp_table_name = f"temp_{file_spec.file_type.value}_{safe_filename}_{id(file_spec)}"
@@ -292,7 +301,7 @@ class GraphDatabase:
             # slot list we know the read schema already, so derive the exclude
             # from the slots instead of DESCRIBE-ing the file — keeping the
             # explicit-schema path to a single read (FIFO/stream-safe).
-            if file_spec.slots:
+            if explicit_columns:
                 exclude_clause = _injected_exclude_from_slots(file_spec.slots, generate_provided_by)
             else:
                 exclude_clause = _build_injected_columns_exclude(
@@ -340,10 +349,12 @@ class GraphDatabase:
 
             # Transform pipe-delimited multivalued fields to arrays
             # Skip file_source and provided_by (when generated) since we add them as literals.
-            # When the user supplied explicit slots, the column types already reflect
-            # Biolink's multivalued declarations; the single-valued flatten path
-            # would undo that, so skip the transform entirely.
-            if not file_spec.slots:
+            # When the user supplied explicit slots on the JSONL path, the column
+            # types already reflect Biolink's multivalued declarations; the
+            # single-valued flatten path would undo that, so skip the transform
+            # entirely. For TSV/Parquet (read_csv/read_parquet ignore the slots)
+            # the columns are still pipe-delimited scalars and need the transform.
+            if not explicit_columns:
                 skip_columns = {"file_source"}
                 if generate_provided_by:
                     skip_columns.add("provided_by")

--- a/tests/test_load_stream.py
+++ b/tests/test_load_stream.py
@@ -1,0 +1,91 @@
+"""Single-pass load on the explicit-columns path.
+
+With `--slots-file`, the read schema is known up front, so the loader skips the
+collision-detection DESCRIBE and touches each input exactly once. That makes a
+load readable from a non-seekable stream (a FIFO fed by `tar -xO …`), so a
+compressed release can be loaded without first extracting its multi-GB JSONL.
+
+These tests would hang (caught by the join-timeout) if the loader regressed to
+re-reading the input.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+
+import duckdb
+import pytest
+
+from koza.graph_operations import load_graph, prepare_load_config_from_paths
+
+
+def _feed_fifo(path, text: str) -> threading.Thread:
+    """Write `text` into a FIFO from a daemon thread (open-for-write blocks until
+    the loader opens the read end)."""
+
+    def run():
+        with open(path, "w") as f:
+            f.write(text)
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    return t
+
+
+def _run_with_timeout(cfg, seconds=30):
+    box = {}
+
+    def run():
+        box["result"] = load_graph(cfg)
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    t.join(timeout=seconds)
+    assert not t.is_alive(), "load_graph hung on the FIFO — it re-read a non-seekable input"
+    return box["result"]
+
+
+@pytest.fixture
+def slots_file(tmp_path):
+    p = tmp_path / "slots.yaml"
+    # edges declares file_source so we can check the slots-based collision exclude
+    p.write_text(
+        "nodes: [id, category, name]\n"
+        "edges: [id, subject, predicate, object, file_source]\n"
+    )
+    return p
+
+
+def test_load_streams_from_fifo_single_pass(tmp_path, slots_file):
+    nodes_fifo = tmp_path / "nodes.jsonl"
+    edges_fifo = tmp_path / "edges.jsonl"
+    os.mkfifo(nodes_fifo)
+    os.mkfifo(edges_fifo)
+
+    nodes_txt = "".join(
+        f'{{"id":"GENE:{i}","category":["biolink:Gene"],"name":"g{i}"}}\n' for i in range(5)
+    )
+    edges_txt = "".join(
+        f'{{"id":"e{i}","subject":"GENE:{i}","predicate":"biolink:related_to",'
+        f'"object":"GENE:{(i + 1) % 5}","file_source":"upstream"}}\n'
+        for i in range(5)
+    )
+    _feed_fifo(nodes_fifo, nodes_txt)
+    _feed_fifo(edges_fifo, edges_txt)
+
+    db = tmp_path / "g.duckdb"
+    cfg = prepare_load_config_from_paths(
+        [nodes_fifo], [edges_fifo], output_database=db, slots_file=slots_file,
+        quiet=True, show_progress=False,
+    )
+    result = _run_with_timeout(cfg)
+
+    assert result.final_stats.nodes == 5
+    assert result.final_stats.edges == 5
+    # the input's own file_source was excluded (slots-based, no read) and koza's
+    # injected one kept — exactly one file_source column, no auto-renamed dup
+    con = duckdb.connect(str(db), read_only=True)
+    cols = [r[0] for r in con.execute("DESCRIBE edges").fetchall()]
+    assert cols.count("file_source") == 1
+    assert "file_source_1" not in cols

--- a/tests/test_load_stream.py
+++ b/tests/test_load_stream.py
@@ -37,12 +37,17 @@ def _run_with_timeout(cfg, seconds=30):
     box = {}
 
     def run():
-        box["result"] = load_graph(cfg)
+        try:
+            box["result"] = load_graph(cfg)
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the main thread below
+            box["error"] = exc
 
     t = threading.Thread(target=run, daemon=True)
     t.start()
     t.join(timeout=seconds)
     assert not t.is_alive(), "load_graph hung on the FIFO — it re-read a non-seekable input"
+    if "error" in box:
+        raise box["error"]
     return box["result"]
 
 
@@ -57,6 +62,12 @@ def slots_file(tmp_path):
     return p
 
 
+requires_fifo = pytest.mark.skipif(
+    not hasattr(os, "mkfifo"), reason="os.mkfifo is not available on this platform"
+)
+
+
+@requires_fifo
 def test_load_streams_from_fifo_single_pass(tmp_path, slots_file):
     nodes_fifo = tmp_path / "nodes.jsonl"
     edges_fifo = tmp_path / "edges.jsonl"
@@ -89,3 +100,73 @@ def test_load_streams_from_fifo_single_pass(tmp_path, slots_file):
     cols = [r[0] for r in con.execute("DESCRIBE edges").fetchall()]
     assert cols.count("file_source") == 1
     assert "file_source_1" not in cols
+
+
+def _write_tsv(path, header, rows):
+    lines = ["\t".join(header)]
+    lines += ["\t".join(r) for r in rows]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def test_tsv_with_slots_excludes_input_file_source(tmp_path):
+    """A slots file is set on every input regardless of format, but for TSV the
+    read schema is the file's real columns — not the slots. The collision exclude
+    must therefore come from a DESCRIBE, otherwise the input's own file_source
+    survives and koza's injected one auto-renames to file_source_1."""
+    slots = tmp_path / "slots.yaml"
+    # edges slots OMIT file_source even though the TSV header carries it
+    slots.write_text(
+        "nodes: [id, category, name]\n"
+        "edges: [id, subject, predicate, object]\n"
+    )
+    nodes = tmp_path / "nodes.tsv"
+    edges = tmp_path / "edges.tsv"
+    _write_tsv(nodes, ["id", "category", "name"], [[f"GENE:{i}", "biolink:Gene", f"g{i}"] for i in range(3)])
+    _write_tsv(
+        edges,
+        ["id", "subject", "predicate", "object", "file_source"],
+        [[f"e{i}", f"GENE:{i}", "biolink:related_to", f"GENE:{(i + 1) % 3}", "upstream"] for i in range(3)],
+    )
+
+    db = tmp_path / "g.duckdb"
+    cfg = prepare_load_config_from_paths(
+        [nodes], [edges], output_database=db, slots_file=slots, quiet=True, show_progress=False,
+    )
+    result = load_graph(cfg)
+
+    assert result.final_stats.edges == 3
+    con = duckdb.connect(str(db), read_only=True)
+    cols = [r[0] for r in con.execute("DESCRIBE edges").fetchall()]
+    assert cols.count("file_source") == 1
+    assert "file_source_1" not in cols
+
+
+def test_tsv_with_slots_naming_absent_column_loads(tmp_path):
+    """Slots may name a column the TSV file does not have (e.g. file_source). The
+    single-pass path would build an EXCLUDE for that column and DuckDB raises a
+    Binder Error; the DESCRIBE-based path excludes only columns that exist."""
+    slots = tmp_path / "slots.yaml"
+    # edges slots INCLUDE file_source, but the TSV header below has no such column
+    slots.write_text(
+        "nodes: [id, category, name]\n"
+        "edges: [id, subject, predicate, object, file_source]\n"
+    )
+    nodes = tmp_path / "nodes.tsv"
+    edges = tmp_path / "edges.tsv"
+    _write_tsv(nodes, ["id", "category", "name"], [[f"GENE:{i}", "biolink:Gene", f"g{i}"] for i in range(3)])
+    _write_tsv(
+        edges,
+        ["id", "subject", "predicate", "object"],
+        [[f"e{i}", f"GENE:{i}", "biolink:related_to", f"GENE:{(i + 1) % 3}"] for i in range(3)],
+    )
+
+    db = tmp_path / "g.duckdb"
+    cfg = prepare_load_config_from_paths(
+        [nodes], [edges], output_database=db, slots_file=slots, quiet=True, show_progress=False,
+    )
+    result = load_graph(cfg)
+
+    assert result.final_stats.edges == 3
+    con = duckdb.connect(str(db), read_only=True)
+    cols = [r[0] for r in con.execute("DESCRIBE edges").fetchall()]
+    assert cols.count("file_source") == 1


### PR DESCRIPTION
## What

When `--slots-file` supplies an explicit read schema, `load` still ran a
collision-detection `DESCRIBE SELECT * FROM read_json(...)` before the main
`CREATE` — a **second read** of the input. With explicit columns the read schema
*is* the slot list, so the `file_source`/`provided_by` collision check can be
computed from the slots alone, with no read.

This refactors `_build_injected_columns_exclude` into shared helpers and adds
`_injected_exclude_from_slots` (slots in → EXCLUDE clause, no file touch).
`load_file` uses it whenever `file_spec.slots` is set; the inferred/TSV path is
unchanged (still DESCRIBEs).

## Why

1. **Every explicit-columns load drops a redundant full `DESCRIBE` scan.**
2. **The explicit-columns load now touches each input exactly once**, so it can
   read a *non-seekable stream* — e.g. a FIFO fed by
   `tar --use-compress-program=unzstd -xOf release.tar.zst edges.jsonl`. That
   lets a compressed KGX release (the Translator `*.tar.zst` builds) load
   straight into DuckDB **without first extracting its multi-GB JSONL to disk** —
   the difference between needing 27 GB of scratch space for `translator_kg` and
   needing ~none.

## Test

`tests/test_load_stream.py` loads nodes+edges from **FIFOs** with a `slots-file`
(it would hang — caught by a join-timeout — if the loader re-read a non-seekable
input), and asserts the slots-based collision exclude drops a pre-existing
`file_source` without auto-renaming. Full suite: **416 passed**.

## Caveat / scope

This is the **library** behavior (`load_graph`). The `koza` **CLI** driven by a
shell `cat`/`tar > fifo &` writer can still hang on FIFO open-ordering *between
the two processes* (not a load-logic issue — the same load streams fine via the
library and via direct DuckDB). Recommended streaming entry point for now is the
library or a direct DuckDB read; a CLI-level `archive.tar.zst!member` reader
could be a clean follow-up.