### PR TITLE
Restore optional grape/ml deps (ensmallen, embiggen) now un-quarantined

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,23 +30,15 @@ dependencies = [
     "LinkML>=1.9.0"
 ]
 
-# NOTE: `ensmallen` and `embiggen` are temporarily removed from the extras
-# below. Both were quarantined on PyPI during the mini-Shai-Hulud supply-chain
-# wave (their /simple/ pages return project-status "quarantined" with zero
-# downloadable files for ALL versions), which makes `uv lock` unsatisfiable and
-# breaks CI for every PR. Restore the pins once PyPI de-quarantines them (or the
-# maintainers cut clean releases). Until then, the connectivity report's
-# ensmallen import degrades gracefully via `_check_ensmallen_available()`; users
-# who need it must install ensmallen manually from a trusted source.
 [project.optional-dependencies]
 grape = [
-    # "ensmallen==0.8.99",  # quarantined on PyPI — see note above
+    "ensmallen==0.8.99",
     "pandas",
     "pyarrow",
 ]
 ml = [
-    # "ensmallen==0.8.99",  # quarantined on PyPI — see note above
-    # "embiggen>=0.11",     # quarantined on PyPI (pulls ensmallen) — see note above
+    "ensmallen==0.8.99",
+    "embiggen>=0.11",
     "pandas",
     "pyarrow",
 ]


### PR DESCRIPTION
Re-enables the `ensmallen`/`embiggen` pins in the `grape` and `ml` optional-dependency extras, reverting #223 / a400e50, which commented them out when PyPI quarantined them during the Sept-2025 mini-Shai-Hulud supply-chain wave. PyPI has since de-quarantined the packages.

## Why the pin stays at `ensmallen==0.8.99` (not 0.8.100)

`0.8.100` is the newer release, but its `macosx_11_0_arm64` wheel **fails to import on Apple Silicon**:

```
ImportError: cannot import name 'ensmallen_default' from partially initialized module 'ensmallen'
```

`0.8.99` imports and builds graphs fine on arm64. Verified empirically by installing each version into a throwaway venv on arm64 Darwin and importing. So we keep the original exact pin.

## Lock note

`uv.lock` is unchanged: a400e50 only edited `pyproject.toml` and never regenerated the lock, so the lock already carried the ensmallen/embiggen entries (with hashes). This PR just re-syncs `pyproject.toml` to it. `uv lock --check` passes.

## Supply-chain re-verification (before restoring)

| Check | Result |
|---|---|
| PyPI file hashes vs `uv.lock` pins | Identical — files not swapped under the lock |
| OSV advisories (ensmallen, embiggen + same-author transitive deps) | None |
| Wheel install hooks / scripts / entry points | None (wheels don't run `setup.py`) |
| embiggen sdist `setup.py` | Standard GRAPE setup, no network/exec; provenance `monarch-initiative` |
| IOC sweep (worm signatures, exec/eval/exfil, dropped JS/sh/workflow) | Clean |
| ensmallen `.so` dynamic linkage | System frameworks only |

The de-quarantine lifted PyPI's hold on the same Sept-2025 files; those files show no IOCs. `uv.lock` hash-pinning continues to guard future installs against any tampered re-upload.

## Notes / follow-ups
- The connectivity report already degrades gracefully when ensmallen is absent (`_check_ensmallen_available()`), so this only affects users who opt into `koza[grape]` / `koza[ml]`.
- If/when a fixed `ensmallen` arm64 wheel ships (>0.8.100), we can bump.

https://claude.ai/code/session_01RkCtLnZZ6bicTvTA1yAX1y