### PR TITLE
Fix information-content closure_size for multivalued (VARCHAR[]) category

### DIFF
--- a/src/koza/graph_operations/information_content.py
+++ b/src/koza/graph_operations/information_content.py
@@ -96,14 +96,25 @@ def compute_information_content(config: InformationContentConfig) -> Information
             ).fetchone()[0]
 
             # closure_size: per entity, the number of distinct closure ancestors
-            # (subsumers) of the terms it is associated with.
+            # (subsumers) of the terms it is associated with. `category` may be
+            # single-valued (VARCHAR) or multivalued (VARCHAR[] — koza's default
+            # for Biolink-multivalued slots), so pick the matching membership
+            # test: scalar IN vs list_has_any on the array.
+            cat_type = conn.execute(
+                "SELECT data_type FROM information_schema.columns "
+                f"WHERE table_name = '{config.edges_table}' AND column_name = 'category'"
+            ).fetchone()
+            if cat_type and cat_type[0].endswith("[]"):
+                category_filter = f"list_has_any(category, [{categories}])"
+            else:
+                category_filter = f"category IN ({categories})"
             conn.execute(f"""
                 CREATE OR REPLACE TABLE closure_size AS
                 WITH assoc AS (
                     SELECT {config.association_subject_column} AS entity,
                            {config.association_object_column} AS term
                     FROM {config.edges_table}
-                    WHERE category IN ({categories})
+                    WHERE {category_filter}
                       AND predicate = {_quote_list([config.association_predicate])}{negated_filter}
                 ),
                 clo AS (

--- a/tests/test_information_content.py
+++ b/tests/test_information_content.py
@@ -169,3 +169,47 @@ def test_information_content_custom_closure_predicate(closurized_kg):
     with GraphDatabase(closurized_kg) as db:
         terms = {r[0] for r in db.conn.execute("SELECT term FROM information_content").fetchall()}
     assert terms == {"GO:1"}
+
+
+@pytest.fixture
+def closurized_kg_multivalued_category(tmp_path):
+    """Like closurized_kg, but edges.category is VARCHAR[] (koza's default for
+    Biolink-multivalued slots) — exercises the list_has_any path in closure_size."""
+    db_path = tmp_path / "kg_mv.duckdb"
+    with GraphDatabase(db_path) as db:
+        db.conn.execute("""
+            CREATE TABLE closure (subject_id VARCHAR, predicate_id VARCHAR, object_id VARCHAR);
+            INSERT INTO closure VALUES
+                ('HP:1', 'rdfs:subClassOf', 'HP:1'),
+                ('HP:1', 'rdfs:subClassOf', 'HP:0'),
+                ('HP:1', 'rdfs:subClassOf', 'HP:ROOT'),
+                ('HP:0', 'rdfs:subClassOf', 'HP:0'),
+                ('HP:0', 'rdfs:subClassOf', 'HP:ROOT'),
+                ('HP:ROOT', 'rdfs:subClassOf', 'HP:ROOT');
+        """)
+        db.conn.execute("""
+            CREATE TABLE edges (id VARCHAR, subject VARCHAR, predicate VARCHAR, object VARCHAR,
+                                category VARCHAR[], negated BOOLEAN);
+            INSERT INTO edges VALUES
+                ('e1', 'GENE:1', 'biolink:has_phenotype', 'HP:1',
+                 ['biolink:GeneToPhenotypicFeatureAssociation'], false),
+                ('e2', 'DISEASE:1', 'biolink:has_phenotype', 'HP:0',
+                 ['biolink:DiseaseToPhenotypicFeatureAssociation'], false),
+                ('e3', 'GENE:2', 'biolink:has_phenotype', 'HP:1',
+                 ['biolink:GeneToGeneAssociation'], false);
+        """)
+    return db_path
+
+
+def test_closure_size_handles_multivalued_category(closurized_kg_multivalued_category):
+    """`category` as VARCHAR[] must use list_has_any, not scalar IN (which throws
+    a cast error on the array column). Regression for the production monarch-kg,
+    where merge preserves Biolink-multivalued category."""
+    result = compute_information_content(
+        InformationContentConfig(database_path=closurized_kg_multivalued_category, quiet=True)
+    )
+    assert result.success
+    with GraphDatabase(closurized_kg_multivalued_category) as db:
+        size = dict(db.conn.execute("SELECT entity, size FROM closure_size").fetchall())
+    # GENE:1 -> {HP:1,HP:0,HP:ROOT}=3; DISEASE:1 -> {HP:0,HP:ROOT}=2; GENE:2 dropped (category)
+    assert size == {"GENE:1": 3, "DISEASE:1": 2}


### PR DESCRIPTION
## Problem

`compute_information_content` builds `closure_size` by filtering associations with `category IN (...)`. When `edges.category` is a **list** (`VARCHAR[]`) — the shape koza's own merge produces for Biolink-multivalued slots, and what the production monarch-kg has — DuckDB throws:

```
ConversionException: Type VARCHAR with value 'biolink:GeneToPhenotypicFeatureAssociation'
can't be cast to the destination type VARCHAR[]
```

So `information_content` builds (it only reads the closure table) but `closure_size` fails. Caught by a local full monarch-kg build.

## Fix

Detect the `category` column type and choose the membership test accordingly:
- `VARCHAR[]` → `list_has_any(category, [...])`
- scalar `VARCHAR` → `category IN (...)` (unchanged)

Verified against the real monarch-kg: `closure_size` now builds (51,581 entities). Adds a regression test with `category VARCHAR[]`. All information-content tests pass.

## Note

This is a patch on the `information-content` op shipped in 2.6.0 — suggest a **2.6.1** release. (The monarch-app similarity engine has the same scalar-`category` assumption in its non-baked association path; it needs the same array-aware treatment before it attaches the full multivalued monarch-kg — tracked separately.)

https://claude.ai/code/session_01SMhNpLnWjUztXLtB5pdjPp