### PR TITLE
Enforce writer min/max node and edge count bounds

### DIFF
--- a/src/koza/io/writer/jsonl_writer.py
+++ b/src/koza/io/writer/jsonl_writer.py
@@ -22,6 +22,7 @@ class JSONLWriter(KozaWriter):
     ):
         self.output_dir = output_dir
         self.source_name = source_name
+        self.config = config
         self.sssom_config = config.sssom_config
 
         self.converter = KGXConverter()
@@ -73,6 +74,7 @@ class JSONLWriter(KozaWriter):
             self._node_buf.append(self._serialize(node))
             self._node_buf.append(_NEWLINE)
             self.written_node_ids.add(node_id)
+            self.node_count += 1
             if len(self._node_buf) >= _WRITE_BATCH * 2:
                 self.nodeFH.write(b"".join(self._node_buf))
                 self._node_buf.clear()
@@ -88,6 +90,7 @@ class JSONLWriter(KozaWriter):
                 edge_dict = self.sssom_config.apply_mapping(edge_dict)
                 self._edge_buf.append(orjson.dumps(edge_dict))
                 self._edge_buf.append(_NEWLINE)
+                self.edge_count += 1
                 if len(self._edge_buf) >= _WRITE_BATCH * 2:
                     self.edgeFH.write(b"".join(self._edge_buf))
                     self._edge_buf.clear()
@@ -95,6 +98,7 @@ class JSONLWriter(KozaWriter):
             for edge in edges:
                 self._edge_buf.append(self._serialize(edge))
                 self._edge_buf.append(_NEWLINE)
+                self.edge_count += 1
                 if len(self._edge_buf) >= _WRITE_BATCH * 2:
                     self.edgeFH.write(b"".join(self._edge_buf))
                     self._edge_buf.clear()

--- a/src/koza/io/writer/passthrough_writer.py
+++ b/src/koza/io/writer/passthrough_writer.py
@@ -1,23 +1,28 @@
 from collections.abc import Iterable
 
 from koza.io.writer.writer import KozaWriter
+from koza.model.writer import WriterConfig
 
 
 class PassthroughWriter(KozaWriter):
-    def __init__(self):
+    def __init__(self, config: WriterConfig | None = None):
+        self.config = config
         self.data = []
 
     def write(self, entities: Iterable):
         for item in entities:
             self.data.append(item)
+            self.tally_entity(item)
 
     def write_nodes(self, nodes: Iterable):
         for node in nodes:
             self.data.append(node)
+            self.node_count += 1
 
     def write_edges(self, edges: Iterable):
         for edge in edges:
             self.data.append(edge)
+            self.edge_count += 1
 
     def finalize(self):
         pass

--- a/src/koza/io/writer/tsv_writer.py
+++ b/src/koza/io/writer/tsv_writer.py
@@ -25,6 +25,7 @@ class TSVWriter(KozaWriter):
         self.delimiter = "\t"
         self.list_delimiter = "|"
         self.converter = KGXConverter()
+        self.config = config
         self.sssom_config = config.sssom_config
 
         Path(self.dirname).mkdir(parents=True, exist_ok=True)
@@ -61,6 +62,7 @@ class TSVWriter(KozaWriter):
         for node in nodes:
             node = self.converter.convert_node(node)
             self.write_row(node, record_type="node")
+            self.node_count += 1
 
     def write_edges(self, edges: Iterable):
         for edge in edges:
@@ -68,6 +70,7 @@ class TSVWriter(KozaWriter):
             if self.sssom_config:
                 edge = self.sssom_config.apply_mapping(edge)
             self.write_row(edge, record_type="edge")
+            self.edge_count += 1
 
     def write_row(self, record: dict, record_type: Literal["node", "edge"]) -> None:
         """Write a row to the underlying store.

--- a/src/koza/io/writer/writer.py
+++ b/src/koza/io/writer/writer.py
@@ -40,6 +40,21 @@ class KozaWriter(ABC):
     def finalize(self):
         pass
 
+    def tally_entity(self, entity) -> None:
+        """Increment the node or edge tally for a single, already-written entity.
+
+        Classification is lenient so it can run on the passthrough path, which
+        also carries raw mapping records: anything with subject/object/predicate
+        counts as an edge, anything else with an id counts as a node, and
+        everything else (e.g. a plain mapping dict) is ignored rather than raised
+        on. Writers that already know an entity's kind should increment
+        node_count/edge_count directly instead of calling this.
+        """
+        if all(hasattr(entity, attr) for attr in ("subject", "object", "predicate")):
+            self.edge_count += 1
+        elif hasattr(entity, "id"):
+            self.node_count += 1
+
     def validate_counts(self) -> None:
         """Enforce the writer's configured min/max node and edge counts.
 

--- a/src/koza/io/writer/writer.py
+++ b/src/koza/io/writer/writer.py
@@ -1,5 +1,11 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from koza.utils.exceptions import CountValidationError
+
+if TYPE_CHECKING:
+    from koza.model.writer import WriterConfig
 
 
 class KozaWriter(ABC):
@@ -10,6 +16,13 @@ class KozaWriter(ABC):
     # def writeheader(self) -> Optional[int]:
     #     pass
     """
+
+    #: Set by concrete writers so count validation can read the configured bounds.
+    #: Left as None (the default) by writers without a config, e.g. PassthroughWriter.
+    config: "WriterConfig | None" = None
+    #: Running tallies of rows written, maintained by concrete writers.
+    node_count: int = 0
+    edge_count: int = 0
 
     @abstractmethod
     def write(self, entities: Iterable):
@@ -26,6 +39,30 @@ class KozaWriter(ABC):
     @abstractmethod
     def finalize(self):
         pass
+
+    def validate_counts(self) -> None:
+        """Enforce the writer's configured min/max node and edge counts.
+
+        A no-op when no config (or no bound) is set. Raises CountValidationError
+        naming every violated bound so a build fails loudly rather than shipping a
+        silently truncated graph.
+        """
+        config = self.config
+        if config is None:
+            return
+
+        violations: list[str] = []
+        for label, count, minimum, maximum in (
+            ("node", self.node_count, config.min_node_count, config.max_node_count),
+            ("edge", self.edge_count, config.min_edge_count, config.max_edge_count),
+        ):
+            if minimum is not None and count < minimum:
+                violations.append(f"{label} count {count} is below the configured min_{label}_count of {minimum}")
+            if maximum is not None and count > maximum:
+                violations.append(f"{label} count {count} is above the configured max_{label}_count of {maximum}")
+
+        if violations:
+            raise CountValidationError("; ".join(violations))
 
     def result(self):
         raise NotImplementedError()

--- a/src/koza/runner.py
+++ b/src/koza/runner.py
@@ -293,7 +293,7 @@ class KozaRunner:
         elif config.writer.format == OutputFormat.jsonl:
             writer = JSONLWriter(output_dir=output_dir, source_name=config.name, config=config.writer)
         elif config.writer.format == OutputFormat.passthrough:
-            writer = PassthroughWriter()
+            writer = PassthroughWriter(config=config.writer)
 
         if writer is None:
             raise ValueError("No writer defined")

--- a/src/koza/runner.py
+++ b/src/koza/runner.py
@@ -177,6 +177,7 @@ class KozaRunner:
             self.run_for_tag(tag, mappings)
 
         self.writer.finalize()
+        self.writer.validate_counts()
 
         return self.writer
 

--- a/src/koza/utils/exceptions.py
+++ b/src/koza/utils/exceptions.py
@@ -16,3 +16,7 @@ class MapItemException(KeyError):
 
 class NoTransformException(ValueError):
     """Exception raised when a transform was not passed to KozaRunner"""
+
+
+class CountValidationError(ValueError):
+    """Raised when a writer's node or edge count violates its configured min/max bounds"""

--- a/tests/unit/test_writer_count_validation.py
+++ b/tests/unit/test_writer_count_validation.py
@@ -1,0 +1,151 @@
+"""Tests for writer node/edge count-bound enforcement (min/max_{node,edge}_count)."""
+
+import pytest
+from biolink_model.datamodel.pydanticmodel_v2 import Disease, Gene, VariantToPopulationAssociation
+
+import koza
+from koza.io.writer.jsonl_writer import JSONLWriter
+from koza.io.writer.tsv_writer import TSVWriter
+from koza.model.writer import WriterConfig
+from koza.runner import KozaRunner, KozaTransform, KozaTransformHooks
+from koza.utils.exceptions import CountValidationError
+
+NODE_PROPERTIES = ["id", "category", "symbol"]
+EDGE_PROPERTIES = ["id", "subject", "predicate", "object", "category"]
+
+
+def _entities():
+    gene = Gene(id="HGNC:11603", symbol="TBX4")
+    disease = Disease(id="MONDO:0005002", name="chronic obstructive pulmonary disease")
+    association = VariantToPopulationAssociation(
+        id="uuid:5b06e86f-d768-4cd9-ac27-abe31e95ab1e",
+        subject=gene.id,
+        object=disease.id,
+        predicate="biolink:contributes_to",
+        knowledge_level="not_provided",
+        agent_type="not_provided",
+    )
+    return [gene, disease, association]
+
+
+def _write(writer):
+    writer.write(_entities())
+    writer.finalize()
+
+
+def test_counts_track_written_rows(tmp_path):
+    config = WriterConfig(node_properties=NODE_PROPERTIES, edge_properties=EDGE_PROPERTIES)
+    writer = TSVWriter(tmp_path, "counts", config=config)
+    _write(writer)
+    assert writer.node_count == 2
+    assert writer.edge_count == 1
+
+
+def test_min_edge_count_violation_raises(tmp_path):
+    config = WriterConfig(
+        node_properties=NODE_PROPERTIES,
+        edge_properties=EDGE_PROPERTIES,
+        min_edge_count=100,
+    )
+    writer = TSVWriter(tmp_path, "counts", config=config)
+    _write(writer)
+    with pytest.raises(CountValidationError, match="edge count 1 is below the configured min_edge_count of 100"):
+        writer.validate_counts()
+
+
+def test_min_node_count_violation_raises(tmp_path):
+    config = WriterConfig(
+        node_properties=NODE_PROPERTIES,
+        edge_properties=EDGE_PROPERTIES,
+        min_node_count=100,
+    )
+    writer = TSVWriter(tmp_path, "counts", config=config)
+    _write(writer)
+    with pytest.raises(CountValidationError, match="node count 2 is below the configured min_node_count of 100"):
+        writer.validate_counts()
+
+
+def test_max_edge_count_violation_raises(tmp_path):
+    config = WriterConfig(
+        node_properties=NODE_PROPERTIES,
+        edge_properties=EDGE_PROPERTIES,
+        max_edge_count=0,
+    )
+    writer = TSVWriter(tmp_path, "counts", config=config)
+    _write(writer)
+    with pytest.raises(CountValidationError, match="edge count 1 is above the configured max_edge_count of 0"):
+        writer.validate_counts()
+
+
+def test_counts_within_bounds_pass(tmp_path):
+    config = WriterConfig(
+        node_properties=NODE_PROPERTIES,
+        edge_properties=EDGE_PROPERTIES,
+        min_node_count=1,
+        min_edge_count=1,
+        max_node_count=10,
+        max_edge_count=10,
+    )
+    writer = TSVWriter(tmp_path, "counts", config=config)
+    _write(writer)
+    writer.validate_counts()  # should not raise
+
+
+def test_no_bounds_configured_is_noop(tmp_path):
+    config = WriterConfig(node_properties=NODE_PROPERTIES, edge_properties=EDGE_PROPERTIES)
+    writer = TSVWriter(tmp_path, "counts", config=config)
+    _write(writer)
+    writer.validate_counts()  # no bounds set -> no-op
+
+
+def test_jsonl_writer_counts_and_enforces(tmp_path):
+    config = WriterConfig(min_edge_count=100)
+    writer = JSONLWriter(str(tmp_path), "counts", config=config)
+    _write(writer)
+    assert writer.node_count == 2
+    assert writer.edge_count == 1
+    with pytest.raises(CountValidationError, match="min_edge_count"):
+        writer.validate_counts()
+
+
+def test_runner_run_enforces_min_edge_count(tmp_path):
+    """End-to-end: KozaRunner.run() must raise when the writer falls short of min_edge_count."""
+    config = WriterConfig(edge_properties=EDGE_PROPERTIES, min_edge_count=100)
+    writer = TSVWriter(tmp_path, "counts", config=config)
+
+    @koza.transform_record()
+    def transform_record(koza_transform: KozaTransform, record):
+        koza_transform.write(
+            VariantToPopulationAssociation(
+                id="uuid:5b06e86f-d768-4cd9-ac27-abe31e95ab1e",
+                subject="HGNC:11603",
+                object="MONDO:0005002",
+                predicate="biolink:contributes_to",
+                knowledge_level="not_provided",
+                agent_type="not_provided",
+            )
+        )
+
+    runner = KozaRunner(
+        data=[{"a": 1}],
+        writer=writer,
+        hooks=KozaTransformHooks(transform_record=[transform_record]),
+    )
+    with pytest.raises(CountValidationError, match="min_edge_count"):
+        runner.run()
+
+
+def test_multiple_violations_reported_together(tmp_path):
+    config = WriterConfig(
+        node_properties=NODE_PROPERTIES,
+        edge_properties=EDGE_PROPERTIES,
+        min_node_count=100,
+        min_edge_count=100,
+    )
+    writer = TSVWriter(tmp_path, "counts", config=config)
+    _write(writer)
+    with pytest.raises(CountValidationError) as exc:
+        writer.validate_counts()
+    message = str(exc.value)
+    assert "min_node_count" in message
+    assert "min_edge_count" in message

--- a/tests/unit/test_writer_count_validation.py
+++ b/tests/unit/test_writer_count_validation.py
@@ -5,6 +5,7 @@ from biolink_model.datamodel.pydanticmodel_v2 import Disease, Gene, VariantToPop
 
 import koza
 from koza.io.writer.jsonl_writer import JSONLWriter
+from koza.io.writer.passthrough_writer import PassthroughWriter
 from koza.io.writer.tsv_writer import TSVWriter
 from koza.model.writer import WriterConfig
 from koza.runner import KozaRunner, KozaTransform, KozaTransformHooks
@@ -106,6 +107,65 @@ def test_jsonl_writer_counts_and_enforces(tmp_path):
     assert writer.edge_count == 1
     with pytest.raises(CountValidationError, match="min_edge_count"):
         writer.validate_counts()
+
+
+def test_passthrough_writer_counts_and_enforces():
+    config = WriterConfig(min_edge_count=100)
+    writer = PassthroughWriter(config=config)
+    _write(writer)
+    assert writer.node_count == 2
+    assert writer.edge_count == 1
+    assert len(writer.result()) == 3  # entities pass through untouched
+    with pytest.raises(CountValidationError, match="min_edge_count"):
+        writer.validate_counts()
+
+
+def test_passthrough_writer_ignores_non_entities():
+    """The mappings path writes raw dict records through a passthrough writer;
+    these must pass through untouched and not be miscounted as nodes/edges."""
+    config = WriterConfig(min_node_count=1, min_edge_count=1)
+    writer = PassthroughWriter(config=config)
+    rows = [{"key": "a", "value": "1"}, {"key": "b", "value": "2"}]
+    writer.write(rows)
+    writer.finalize()
+    assert writer.result() == rows
+    assert writer.node_count == 0
+    assert writer.edge_count == 0
+    with pytest.raises(CountValidationError):
+        writer.validate_counts()
+
+
+def test_passthrough_writer_no_config_is_noop():
+    writer = PassthroughWriter()
+    _write(writer)
+    writer.validate_counts()  # config is None -> no-op even though counts are tracked
+
+
+def test_runner_passthrough_enforces_min_edge_count():
+    """End-to-end through KozaRunner with a passthrough writer."""
+    config = WriterConfig(min_edge_count=100)
+    writer = PassthroughWriter(config=config)
+
+    @koza.transform_record()
+    def transform_record(koza_transform: KozaTransform, record):
+        koza_transform.write(
+            VariantToPopulationAssociation(
+                id="uuid:5b06e86f-d768-4cd9-ac27-abe31e95ab1e",
+                subject="HGNC:11603",
+                object="MONDO:0005002",
+                predicate="biolink:contributes_to",
+                knowledge_level="not_provided",
+                agent_type="not_provided",
+            )
+        )
+
+    runner = KozaRunner(
+        data=[{"a": 1}],
+        writer=writer,
+        hooks=KozaTransformHooks(transform_record=[transform_record]),
+    )
+    with pytest.raises(CountValidationError, match="min_edge_count"):
+        runner.run()
 
 
 def test_runner_run_enforces_min_edge_count(tmp_path):


### PR DESCRIPTION
Closes #239

## Problem

`WriterConfig` has long accepted `min_node_count`, `min_edge_count`, `max_node_count`, and `max_edge_count`, and `SourceConfig.to_new_transform()` faithfully passes them through — but **nothing ever reads them**. The fields parse and are silently ignored, so an ingest can emit a truncated or even empty graph and still exit 0.

This just bit go-ingest: a GO upstream format change (the `-mod` GAF files switched the Taxon column prefix from `taxon:` to `NCBITaxon:`) silently dropped ~47% of edges — eight model-organism species collapsed, two to zero rows — and shipped a release before anyone noticed. A `min_edge_count` in the source config would have caught it at build time, if it did anything.

Empirically on unpatched koza, `min_edge_count: 999999999` against an 18-edge transform exits 0.

## Fix

Wire the existing config fields up:

- **`KozaWriter`** gains `node_count`/`edge_count` tallies and a `validate_counts()` method that raises `CountValidationError` naming every violated bound. It is a no-op when no config or no bound is set (e.g. `PassthroughWriter`, `MockWriter`).
- **`TSVWriter`**, **`JSONLWriter`**, and **`PassthroughWriter`** store their `config` and increment the tallies as rows are written (the JSONL node tally follows its existing id de-duplication, so it matches what lands in the file). `PassthroughWriter.write()` appends entities directly, so it counts via a lenient `KozaWriter.tally_entity()` helper that ignores non-entities — the mappings path runs raw dict records through a passthrough writer and those must pass through untouched.
- **`KozaRunner.run()`** calls `validate_counts()` after `finalize()`, so the build fails loudly rather than emitting a short graph.

New exception `CountValidationError(ValueError)` in `koza.utils.exceptions`.

## Tests

`tests/unit/test_writer_count_validation.py` covers: tallies match written rows; under-min (node and edge) raises; over-max raises; within-bounds and no-bounds are no-ops; multiple violations are reported together; both TSV and JSONL writers; and an end-to-end `KozaRunner.run()` that raises when short of `min_edge_count`.

Covers all three writers (TSV, JSONL, passthrough) at both the writer and `KozaRunner.run()` levels, plus a non-entity (mapping record) safety test. Full suite: 409 passed, 10 skipped — no regressions, 13 new tests.

## Verified downstream

Ran a real go-ingest transform against this branch with `min_edge_count: 100000`:
- broken filter → 2,772 edges → `CountValidationError`, exit 1
- fixed filter → 218,380 edges → exit 0

https://claude.ai/code/session_01EEmWQVnmV7nFMca8LfWzYz

