### PR TITLE
Enforce count bounds in writer finalize and log output counts

### DIFF
--- a/src/koza/io/writer/jsonl_writer.py
+++ b/src/koza/io/writer/jsonl_writer.py
@@ -114,3 +114,4 @@ class JSONLWriter(KozaWriter):
                 self.edgeFH.write(b"".join(self._edge_buf))
                 self._edge_buf.clear()
             self.edgeFH.close()
+        self.validate_counts()

--- a/src/koza/io/writer/passthrough_writer.py
+++ b/src/koza/io/writer/passthrough_writer.py
@@ -25,7 +25,7 @@ class PassthroughWriter(KozaWriter):
             self.edge_count += 1
 
     def finalize(self):
-        pass
+        self.validate_counts()
 
     def result(self):
         return self.data

--- a/src/koza/io/writer/tsv_writer.py
+++ b/src/koza/io/writer/tsv_writer.py
@@ -99,6 +99,7 @@ class TSVWriter(KozaWriter):
             self.nodeFH.close()
         if hasattr(self, "edgeFH"):
             self.edgeFH.close()
+        self.validate_counts()
 
     @staticmethod
     def _order_columns(cols: list[str], record_type: Literal["node", "edge"]) -> OrderedSet[str]:

--- a/src/koza/io/writer/writer.py
+++ b/src/koza/io/writer/writer.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
+from loguru import logger
+
 from koza.utils.exceptions import CountValidationError
 
 if TYPE_CHECKING:
@@ -65,6 +67,8 @@ class KozaWriter(ABC):
         config = self.config
         if config is None:
             return
+
+        logger.info(f"Wrote {self.node_count} nodes and {self.edge_count} edges")
 
         violations: list[str] = []
         for label, count, minimum, maximum in (

--- a/tests/unit/test_writer_count_validation.py
+++ b/tests/unit/test_writer_count_validation.py
@@ -42,40 +42,40 @@ def test_counts_track_written_rows(tmp_path):
     assert writer.edge_count == 1
 
 
-def test_min_edge_count_violation_raises(tmp_path):
+def test_min_edge_count_violation_raises_on_finalize(tmp_path):
     config = WriterConfig(
         node_properties=NODE_PROPERTIES,
         edge_properties=EDGE_PROPERTIES,
         min_edge_count=100,
     )
     writer = TSVWriter(tmp_path, "counts", config=config)
-    _write(writer)
+    writer.write(_entities())
     with pytest.raises(CountValidationError, match="edge count 1 is below the configured min_edge_count of 100"):
-        writer.validate_counts()
+        writer.finalize()
 
 
-def test_min_node_count_violation_raises(tmp_path):
+def test_min_node_count_violation_raises_on_finalize(tmp_path):
     config = WriterConfig(
         node_properties=NODE_PROPERTIES,
         edge_properties=EDGE_PROPERTIES,
         min_node_count=100,
     )
     writer = TSVWriter(tmp_path, "counts", config=config)
-    _write(writer)
+    writer.write(_entities())
     with pytest.raises(CountValidationError, match="node count 2 is below the configured min_node_count of 100"):
-        writer.validate_counts()
+        writer.finalize()
 
 
-def test_max_edge_count_violation_raises(tmp_path):
+def test_max_edge_count_violation_raises_on_finalize(tmp_path):
     config = WriterConfig(
         node_properties=NODE_PROPERTIES,
         edge_properties=EDGE_PROPERTIES,
         max_edge_count=0,
     )
     writer = TSVWriter(tmp_path, "counts", config=config)
-    _write(writer)
+    writer.write(_entities())
     with pytest.raises(CountValidationError, match="edge count 1 is above the configured max_edge_count of 0"):
-        writer.validate_counts()
+        writer.finalize()
 
 
 def test_counts_within_bounds_pass(tmp_path):
@@ -89,35 +89,42 @@ def test_counts_within_bounds_pass(tmp_path):
     )
     writer = TSVWriter(tmp_path, "counts", config=config)
     _write(writer)
-    writer.validate_counts()  # should not raise
 
 
 def test_no_bounds_configured_is_noop(tmp_path):
     config = WriterConfig(node_properties=NODE_PROPERTIES, edge_properties=EDGE_PROPERTIES)
     writer = TSVWriter(tmp_path, "counts", config=config)
     _write(writer)
-    writer.validate_counts()  # no bounds set -> no-op
 
 
 def test_jsonl_writer_counts_and_enforces(tmp_path):
     config = WriterConfig(min_edge_count=100)
     writer = JSONLWriter(str(tmp_path), "counts", config=config)
-    _write(writer)
+    writer.write(_entities())
     assert writer.node_count == 2
     assert writer.edge_count == 1
     with pytest.raises(CountValidationError, match="min_edge_count"):
-        writer.validate_counts()
+        writer.finalize()
+
+
+def test_jsonl_writer_node_count_is_post_dedup(tmp_path):
+    config = WriterConfig()
+    writer = JSONLWriter(str(tmp_path), "counts", config=config)
+    gene = Gene(id="HGNC:11603", symbol="TBX4")
+    writer.write_nodes([gene, gene, gene])
+    writer.finalize()
+    assert writer.node_count == 1
 
 
 def test_passthrough_writer_counts_and_enforces():
     config = WriterConfig(min_edge_count=100)
     writer = PassthroughWriter(config=config)
-    _write(writer)
+    writer.write(_entities())
     assert writer.node_count == 2
     assert writer.edge_count == 1
-    assert len(writer.result()) == 3  # entities pass through untouched
+    assert len(writer.result()) == 3
     with pytest.raises(CountValidationError, match="min_edge_count"):
-        writer.validate_counts()
+        writer.finalize()
 
 
 def test_passthrough_writer_ignores_non_entities():
@@ -127,18 +134,16 @@ def test_passthrough_writer_ignores_non_entities():
     writer = PassthroughWriter(config=config)
     rows = [{"key": "a", "value": "1"}, {"key": "b", "value": "2"}]
     writer.write(rows)
-    writer.finalize()
     assert writer.result() == rows
     assert writer.node_count == 0
     assert writer.edge_count == 0
     with pytest.raises(CountValidationError):
-        writer.validate_counts()
+        writer.finalize()
 
 
 def test_passthrough_writer_no_config_is_noop():
     writer = PassthroughWriter()
     _write(writer)
-    writer.validate_counts()  # config is None -> no-op even though counts are tracked
 
 
 def test_runner_passthrough_enforces_min_edge_count():
@@ -203,9 +208,9 @@ def test_multiple_violations_reported_together(tmp_path):
         min_edge_count=100,
     )
     writer = TSVWriter(tmp_path, "counts", config=config)
-    _write(writer)
+    writer.write(_entities())
     with pytest.raises(CountValidationError) as exc:
-        writer.validate_counts()
+        writer.finalize()
     message = str(exc.value)
     assert "min_node_count" in message
     assert "min_edge_count" in message


### PR DESCRIPTION
Closes #201

## Problem

Writer count bounds are enforced from the runner (#238), but `finalize()` itself did not validate. A write → finalize path could skip the check. Bounds are also hard to calibrate without seeing actual output volume each run, and JSONL post-dedup counting lacked a focused regression test.

## Fix

- Call `validate_counts()` from TSV / JSONL / Passthrough `finalize()`
- Keep the runner `validate_counts()` call after `finalize()` as a second line of defense
- Log node/edge counts via loguru in `validate_counts()` when a writer config is present
- Add a JSONL post-dedup count test; adjust tests to expect errors on `finalize()`

## Context

Count bounds exist so an ingest fails when output volume collapses (e.g. go-ingest silently dropping ~47% of edges when an upstream format changed). Absolute min/max enforcement is already on main via the runner (#238); this change puts the same check in `finalize()` so write→finalize paths cannot skip it, and keeps the runner call as a second line of defense.

**Logging:** history showed these fields were easy to ignore and hard to calibrate. Logging actual node/edge counts each run makes collapses and bound-tuning visible in CI/build logs without a separate audit system. I deliberately did *not* restore the old 70% warn/fail thresholds from the pre-rewrite CLI — #238 chose hard absolute bounds after a real outage; this keeps that model and only adds visibility.

**JSONL dedup test:** JSONL skips duplicate node IDs; TSV does not. Bounds must use post-write counts or the guardrail can pass on inflated numbers. #201 called this out; #238 implemented post-dedup counting but lacked a focused regression test — I added one.

## Tests

`tests/unit/test_writer_count_validation.py` — under/over bounds on finalize, within-bounds / no-bounds, JSONL post-dedup, passthrough, runner e2e.

Full suite: `pytest tests` — 474 passed, 10 skipped.